### PR TITLE
Fix Hyprland grouped window previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and dragging windows between workspaces.
 * **Bar Reserved Area Awareness**: Dynamically detects the Omarchy Bar's position (top, bottom, left, right), size, and visibility (`shell.bar`), positioning cards within the safe usable area so they never overlap the bar.
 * **Always-Centered Adaptive Grid**: Evaluates valid row and column arrangements so the complete workspace grid stays centered on landscape, portrait, ultrawide, scaled, and constrained displays—including six-card layouts.
 * **Event-Driven Reactivity**: Listens directly to Hyprland compositor events (`window*`, `workspace*`, `fullscreen`, `changefloatingmode`, `monitor*`) for instant, lag-free UI synchronization without polling.
+* **Grouped Window Previews**: Hyprland grouped/tabbed windows render as a single spatial container with tab indicators for all group members and live capture for the active member.
 * **Optional Compositor Blur**: Exposes a transparent layer-shell surface under `omarchy-workspace-overview`, which Hyprland can blur when configured by the user.
 * **Preserved Interaction Model**: Workspace/window clicks, keyboard navigation, active and selected workspace styling, and drag-and-drop movement continue to use the real spatial preview geometry.
 * **Reliable Overlay Lifecycle**: Mirador remains loaded as a lightweight shell overlay so repeated open/close cycles map instantly.

--- a/WindowModel.js
+++ b/WindowModel.js
@@ -1,0 +1,197 @@
+.pragma library
+
+function normalizedAddress(value) {
+  var address = String(value || "").trim().toLowerCase()
+  if (!address.match(/^(0x)?[0-9a-f]+$/)) return ""
+  return address.indexOf("0x") === 0 ? address : "0x" + address
+}
+
+function ipcObject(toplevel) {
+  return toplevel && toplevel.lastIpcObject ? toplevel.lastIpcObject : null
+}
+
+function toplevelAddress(toplevel) {
+  var ipc = ipcObject(toplevel)
+  return normalizedAddress((toplevel && toplevel.address) || (ipc && ipc.address))
+}
+
+function groupAddresses(toplevel) {
+  var ipc = ipcObject(toplevel)
+  // QVariantList values from Qt are array-like but are not guaranteed to pass
+  // JavaScript's Array.isArray(), unlike the plain arrays used by unit tests.
+  var grouped = ipc && ipc.grouped && typeof ipc.grouped.length === "number"
+    ? ipc.grouped : []
+  if (grouped.length === 0) return []
+
+  var addresses = []
+  for (var i = 0; i < grouped.length; i++) {
+    var address = normalizedAddress(grouped[i])
+    if (address && addresses.indexOf(address) === -1) addresses.push(address)
+  }
+
+  var ownAddress = toplevelAddress(toplevel)
+  if (ownAddress && addresses.indexOf(ownAddress) === -1) addresses.push(ownAddress)
+  return ownAddress && addresses.length >= 2 ? addresses : []
+}
+
+function componentRoot(parents, address) {
+  var root = address
+  while (parents[root] && parents[root] !== root) root = parents[root]
+  while (parents[address] && parents[address] !== address) {
+    var next = parents[address]
+    parents[address] = root
+    address = next
+  }
+  return root
+}
+
+function unionAddresses(parents, left, right) {
+  if (!parents[left]) parents[left] = left
+  if (!parents[right]) parents[right] = right
+  var leftRoot = componentRoot(parents, left)
+  var rightRoot = componentRoot(parents, right)
+  if (leftRoot !== rightRoot) parents[rightRoot] = leftRoot
+}
+
+function betterGroupRepresentative(candidate, current, activeAddress) {
+  if (!current) return true
+
+  var candidateIpc = ipcObject(candidate) || {}
+  var currentIpc = ipcObject(current) || {}
+
+  // 1. Hidden state: hidden === true (e.g. minimized/hidden window) is strongly deprioritized
+  var candidateHidden = candidateIpc.hidden === true
+  var currentHidden = currentIpc.hidden === true
+  if (!candidateHidden && currentHidden) return true
+  if (candidateHidden && !currentHidden) return false
+
+  // 2. Active window address match: if Hyprland's current active window belongs to the group, it wins
+  var normActive = normalizedAddress(activeAddress)
+  if (normActive) {
+    var candidateAddr = toplevelAddress(candidate)
+    var currentAddr = toplevelAddress(current)
+    if (candidateAddr === normActive && currentAddr !== normActive) return true
+    if (candidateAddr !== normActive && currentAddr === normActive) return false
+  }
+
+  // 3. acceptsInput check: in Hyprland, active group tab accepts input while background tabs do not
+  var candidateInput = candidateIpc.acceptsInput === true
+  var currentInput = currentIpc.acceptsInput === true
+  if (candidateInput && !currentInput) return true
+  if (!candidateInput && currentInput) return false
+
+  // 4. focusHistoryID check: lower ID indicates more recently focused tab
+  var candidateFocus = Number(candidateIpc.focusHistoryID)
+  var currentFocus = Number(currentIpc.focusHistoryID)
+  var candidateHasFocus = isFinite(candidateFocus) && candidateFocus >= 0
+  var currentHasFocus = isFinite(currentFocus) && currentFocus >= 0
+
+  if (candidateHasFocus && !currentHasFocus) return true
+  if (!candidateHasFocus && currentHasFocus) return false
+  if (candidateHasFocus && currentHasFocus && candidateFocus !== currentFocus) {
+    return candidateFocus < currentFocus
+  }
+
+  // 5. visible flag fallback
+  if (candidateIpc.visible === true && currentIpc.visible !== true) return true
+  if (candidateIpc.visible !== true && currentIpc.visible === true) return false
+
+  // 6. Stable fallback
+  return false
+}
+
+// Resolve workspace toplevels into structured spatial preview descriptors.
+// For Hyprland groups, exactly one spatial preview is produced with isGroup: true,
+// referencing the active member for screencopy/geometry and retaining all group members.
+function resolveWorkspacePreviews(clients, activeAddress) {
+  var values = clients || []
+  var parents = {}
+  var ownAddresses = []
+
+  // Build connected components for grouped windows
+  for (var i = 0; i < values.length; i++) {
+    var ownAddress = toplevelAddress(values[i])
+    var addresses = groupAddresses(values[i])
+    ownAddresses[i] = ownAddress
+    if (addresses.length < 2) continue
+    for (var addressIndex = 0; addressIndex < addresses.length; addressIndex++) {
+      unionAddresses(parents, ownAddress, addresses[addressIndex])
+    }
+  }
+
+  // Group members and find best representative for each group
+  var groupMembersMap = {}
+  var representatives = {}
+  var keys = []
+
+  for (var candidateIndex = 0; candidateIndex < values.length; candidateIndex++) {
+    var candidateAddress = ownAddresses[candidateIndex]
+    var key = candidateAddress && parents[candidateAddress]
+      ? componentRoot(parents, candidateAddress) : ""
+    keys[candidateIndex] = key
+
+    if (key) {
+      if (!groupMembersMap[key]) groupMembersMap[key] = []
+      groupMembersMap[key].push(values[candidateIndex])
+      if (betterGroupRepresentative(values[candidateIndex], representatives[key], activeAddress)) {
+        representatives[key] = values[candidateIndex]
+      }
+    }
+  }
+
+  var result = []
+  var seenKeys = {}
+
+  for (var j = 0; j < values.length; j++) {
+    var clientKey = keys[j]
+    var client = values[j]
+
+    if (!clientKey) {
+      // Normal ungrouped window or null
+      result.push({
+        type: "window",
+        isGroup: false,
+        toplevel: client,
+        activeMember: client,
+        members: client ? [client] : [],
+        memberCount: client ? 1 : 0,
+        address: toplevelAddress(client),
+        lastIpcObject: ipcObject(client),
+        monitor: client ? client.monitor : null,
+        wayland: client ? client.wayland : null,
+        title: client ? (client.title || "") : ""
+      })
+    } else if (!seenKeys[clientKey]) {
+      seenKeys[clientKey] = true
+      var rep = representatives[clientKey] || client
+      var members = groupMembersMap[clientKey] || [rep]
+      var isRealGroup = members.length > 1
+
+      result.push({
+        type: isRealGroup ? "group" : "window",
+        isGroup: isRealGroup,
+        toplevel: rep,
+        activeMember: rep,
+        members: members,
+        memberCount: members.length,
+        address: toplevelAddress(rep),
+        lastIpcObject: ipcObject(rep),
+        monitor: rep ? rep.monitor : null,
+        wayland: rep ? rep.wayland : null,
+        title: rep ? (rep.title || "") : ""
+      })
+    }
+  }
+
+  return result
+}
+
+// Return active member toplevels for callers expecting plain client arrays.
+function visibleWorkspaceWindows(clients, activeAddress) {
+  var previews = resolveWorkspacePreviews(clients, activeAddress)
+  var result = []
+  for (var i = 0; i < previews.length; i++) {
+    result.push(previews[i] ? previews[i].toplevel : null)
+  }
+  return result
+}

--- a/WindowPreview.qml
+++ b/WindowPreview.qml
@@ -3,26 +3,23 @@ import Quickshell
 import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
+import "WindowModel.js" as WindowModel
 
 Rectangle {
   id: root
 
   required property var toplevel
+  property bool isGroup: false
+  property var groupMembers: []
 
   readonly property var waylandToplevel: toplevel ? toplevel.wayland : null
   readonly property bool activatable: waylandToplevel !== null || (toplevel && String(toplevel.address || "") !== "")
   readonly property bool movable: toplevel !== null && String(toplevel.address || "") !== ""
   readonly property bool dragging: dragProxy.dragSessionActive
-  readonly property string appId: waylandToplevel ? String(waylandToplevel.appId || "") : ""
-  readonly property string title: toplevel ? String(toplevel.title || appId || "Window") : "Window"
-  readonly property var desktopEntry: {
-    if (!appId) return null
-    return DesktopEntries.byId(appId) || DesktopEntries.heuristicLookup(appId)
-  }
-  readonly property string iconSource: {
-    if (!desktopEntry || !desktopEntry.icon) return ""
-    return Quickshell.iconPath(desktopEntry.icon, true)
-  }
+  readonly property string appId: root.appIdFor(toplevel)
+  readonly property string title: root.titleFor(toplevel)
+  readonly property string iconSource: root.iconFor(toplevel)
+
   readonly property real pillHorizontalPadding: Math.max(Style.spacing.sm,
     Style.spacing.controlPaddingX)
   readonly property real pillVerticalPadding: Math.max(2,
@@ -33,14 +30,57 @@ Rectangle {
   readonly property real naturalPillHeight: Math.max(
     titleMetrics.height, iconSource !== "" ? pillIconSize : 0)
     + pillVerticalPadding * 2
-  readonly property bool showTitlePill: width >= Style.space(72)
+
+  readonly property bool showGroupTabs: root.isGroup
+    && root.groupMembers
+    && root.groupMembers.length > 1
+    && width >= Style.space(60)
+    && height >= naturalPillHeight * 1.8
+  readonly property bool showTitlePill: !root.showGroupTabs
+    && width >= Style.space(72)
     && height >= naturalPillHeight * 1.8
 
   property bool liveCaptureEnabled: false
 
   signal activated()
+  signal tabActivated(var targetToplevel)
   signal dragStarted(var toplevel)
   signal dragFinished(var toplevel)
+
+  function appIdFor(top) {
+    if (!top) return ""
+    var wayland = top.wayland
+    if (wayland && wayland.appId) return String(wayland.appId)
+    var ipc = top.lastIpcObject
+    if (ipc && ipc.initialClass) return String(ipc.initialClass)
+    if (ipc && ipc.class) return String(ipc.class)
+    return ""
+  }
+
+  function titleFor(top) {
+    if (!top) return "Window"
+    if (top.title) return String(top.title)
+    var ipc = top.lastIpcObject
+    if (ipc && ipc.title) return String(ipc.title)
+    var id = appIdFor(top)
+    return id || "Window"
+  }
+
+  function iconFor(top) {
+    var id = appIdFor(top)
+    if (!id) return ""
+    var entry = DesktopEntries.byId(id) || DesktopEntries.heuristicLookup(id)
+    if (!entry || !entry.icon) return ""
+    return Quickshell.iconPath(entry.icon, true)
+  }
+
+  function isSameToplevel(a, b) {
+    if (!a || !b) return false
+    if (a === b) return true
+    var addrA = WindowModel.normalizedAddress((a && a.address) || (a.lastIpcObject && a.lastIpcObject.address))
+    var addrB = WindowModel.normalizedAddress((b && b.address) || (b.lastIpcObject && b.lastIpcObject.address))
+    return addrA !== "" && addrA === addrB
+  }
 
   TextMetrics {
     id: titleMetrics
@@ -93,8 +133,7 @@ Rectangle {
     }
   }
 
-  // Interaction chrome is temporary: there is no permanent inner frame
-  // competing with the workspace card's outer border.
+  // Interaction chrome
   Rectangle {
     anchors.fill: parent
     z: 5
@@ -105,9 +144,105 @@ Rectangle {
     radius: root.radius
   }
 
-  // Compact, content-driven metadata floats over the screencopy and never
-  // changes imageArea or spatial geometry. Plain visual children do not
-  // intercept the root's tap/drag handlers.
+  // ── Group Tab Strip ────────────────────────────────────────────────────────
+  Rectangle {
+    id: groupTabBar
+    visible: root.showGroupTabs
+    z: 10
+    anchors.top: parent.top
+    anchors.topMargin: root.pillEdgeInset
+    anchors.horizontalCenter: parent.horizontalCenter
+    width: Math.min(
+      tabRow.implicitWidth + root.pillEdgeInset * 2,
+      Math.max(1, root.width - root.pillEdgeInset * 2))
+    height: root.naturalPillHeight + 2
+    radius: Math.max(3, Style.cornerRadiusSmall || (height / 4))
+    color: Util.alpha(Color.menu.background, 0.88)
+    border.width: 1
+    border.color: Util.alpha(Color.menu.border, 0.15)
+    clip: true
+
+    Row {
+      id: tabRow
+      anchors.fill: parent
+      anchors.margins: 1
+      spacing: 1
+
+      Repeater {
+        model: root.groupMembers
+
+        Rectangle {
+          required property var modelData
+          required property int index
+
+          readonly property bool isCurrentTab: root.isSameToplevel(modelData, root.toplevel)
+          readonly property string tabTitle: root.titleFor(modelData)
+          readonly property string tabIcon: root.iconFor(modelData)
+
+          width: Math.max(1, Math.floor((tabRow.width - (root.groupMembers.length - 1) * tabRow.spacing) / Math.max(1, root.groupMembers.length)))
+          height: parent.height
+          radius: Math.max(2, (Style.cornerRadiusSmall || 4) - 1)
+          color: isCurrentTab
+            ? Util.alpha(Color.accent, 0.32)
+            : (tabHover.hovered ? Util.alpha(Color.menu.text, 0.08) : "transparent")
+
+          border.width: isCurrentTab ? 1 : 0
+          border.color: Util.alpha(Color.accent, 0.6)
+
+          Row {
+            anchors.centerIn: parent
+            width: Math.min(parent.width - Style.spacing.xs * 2, implicitWidth)
+            spacing: Style.spacing.xs
+
+            Image {
+              id: tabAppIcon
+              visible: tabIcon !== ""
+              anchors.verticalCenter: parent.verticalCenter
+              width: visible ? root.pillIconSize : 0
+              height: width
+              source: tabIcon
+              fillMode: Image.PreserveAspectFit
+              asynchronous: true
+              smooth: true
+            }
+
+            Text {
+              anchors.verticalCenter: parent.verticalCenter
+              width: Math.max(1, parent.parent.width - Style.spacing.xs * 2
+                - (tabAppIcon.visible ? tabAppIcon.width + parent.spacing : 0))
+              text: tabTitle
+              textFormat: Text.PlainText
+              color: isCurrentTab ? Color.menu.text : Util.alpha(Color.menu.text, 0.72)
+              font.family: Style.font.menuFamily
+              font.pixelSize: Style.font.bodySmall
+              font.bold: isCurrentTab
+              elide: Text.ElideRight
+              maximumLineCount: 1
+              verticalAlignment: Text.AlignVCenter
+            }
+          }
+
+          HoverHandler {
+            id: tabHover
+            cursorShape: Qt.PointingHandCursor
+          }
+
+          TapHandler {
+            acceptedButtons: Qt.LeftButton
+            onTapped: {
+              if (!isCurrentTab) {
+                root.tabActivated(modelData)
+              } else {
+                root.activated()
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ── Single Window Title Pill ───────────────────────────────────────────────
   Rectangle {
     id: titlePill
     visible: root.showTitlePill

--- a/WorkspaceCard.qml
+++ b/WorkspaceCard.qml
@@ -4,6 +4,7 @@ import Quickshell.Hyprland
 import qs.Commons
 import qs.Ui
 import "WindowGeometry.js" as WindowGeometry
+import "WindowModel.js" as WindowModel
 
 BorderSurface {
   id: root
@@ -15,9 +16,19 @@ BorderSurface {
   property bool keyboardSelected: false
   property var draggedToplevel: null
   property bool livePreviews: false
+  property int toplevelRevision: 0
 
-  readonly property var toplevelModel: workspace ? workspace.toplevels : []
-  readonly property int windowCount: workspace ? workspace.toplevels.values.length : 0
+  readonly property var effectiveToplevels: {
+    // `lastIpcObject` changes after refreshToplevels() completes. Reading this
+    // revision makes that asynchronous, event-driven update invalidate the
+    // effective array even though the ObjectModel membership did not change.
+    var revision = root.toplevelRevision
+    var activeAddr = Hyprland.activeToplevel ? Hyprland.activeToplevel.address : ""
+    return WindowModel.resolveWorkspacePreviews(
+      workspace ? workspace.toplevels.values : [], activeAddr)
+  }
+  readonly property var toplevelModel: effectiveToplevels
+  readonly property int windowCount: effectiveToplevels.length
   readonly property bool occupied: windowCount > 0
 
   readonly property real previewInset: Math.max(2,
@@ -76,6 +87,26 @@ BorderSurface {
   signal windowDragStarted(var toplevel)
   signal windowDragFinished(var toplevel)
   signal windowDropped(var toplevel)
+
+  Connections {
+    target: Hyprland
+    function onActiveToplevelChanged() { root.toplevelRevision++ }
+  }
+
+  // Track the completion of Quickshell's compositor-data refresh for existing
+  // clients. This creates no visual delegate or capture for hidden members.
+  Repeater {
+    model: root.workspace ? root.workspace.toplevels : []
+
+    Item {
+      required property var modelData
+
+      Connections {
+        target: modelData
+        function onLastIpcObjectChanged() { root.toplevelRevision++ }
+      }
+    }
+  }
 
   function screenForMonitor(monitor) {
     if (!monitor) return null
@@ -155,11 +186,16 @@ BorderSurface {
           required property var modelData
           required property int index
 
+          readonly property var previewToplevel: modelData && modelData.toplevel ? modelData.toplevel : modelData
+          readonly property var previewIpc: (modelData && modelData.lastIpcObject)
+            ? modelData.lastIpcObject
+            : (previewToplevel ? previewToplevel.lastIpcObject : null)
+
           readonly property var previewGeometry: WindowGeometry.previewGeometry(
-            modelData ? modelData.lastIpcObject : null,
-            modelData && modelData.monitor ? modelData.monitor : root.workspaceMonitor,
-            root.screenForMonitor(modelData && modelData.monitor
-              ? modelData.monitor : root.workspaceMonitor),
+            previewIpc,
+            previewToplevel && previewToplevel.monitor ? previewToplevel.monitor : root.workspaceMonitor,
+            root.screenForMonitor(previewToplevel && previewToplevel.monitor
+              ? previewToplevel.monitor : root.workspaceMonitor),
             spatialPreview.width,
             spatialPreview.height,
             Math.min(spatialPreview.width, Math.max(Style.space(56), spatialPreview.width * 0.15)),
@@ -174,11 +210,14 @@ BorderSurface {
           width: Math.max(1, displayGeometry.width)
           height: Math.max(1, displayGeometry.height)
           z: index + 1
-          toplevel: modelData
+          toplevel: previewToplevel
+          isGroup: Boolean(modelData && modelData.isGroup)
+          groupMembers: (modelData && modelData.members) ? modelData.members : []
           liveCaptureEnabled: root.livePreviews && root.visible && previewArea.visible
-          onActivated: root.windowActivated(modelData)
-          onDragStarted: root.windowDragStarted(modelData)
-          onDragFinished: root.windowDragFinished(modelData)
+          onActivated: root.windowActivated(previewToplevel)
+          onTabActivated: function(targetToplevel) { root.windowActivated(targetToplevel) }
+          onDragStarted: root.windowDragStarted(previewToplevel)
+          onDragFinished: root.windowDragFinished(previewToplevel)
         }
       }
     }

--- a/WorkspaceOverview.qml
+++ b/WorkspaceOverview.qml
@@ -344,9 +344,11 @@ Item {
         Hyprland.refreshMonitors()
         Hyprland.refreshWorkspaces()
       }
-      if (name.indexOf("window") !== -1 || name === "fullscreen"
-          || name === "changefloatingmode" || name.indexOf("workspace") !== -1)
+      if (name.indexOf("window") !== -1 || name.indexOf("group") !== -1
+          || name === "fullscreen" || name === "changefloatingmode"
+          || name.indexOf("workspace") !== -1 || name === "focusedmon") {
         Hyprland.refreshToplevels()
+      }
     }
   }
 

--- a/tests/tst_windowmodel.qml
+++ b/tests/tst_windowmodel.qml
@@ -1,0 +1,288 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../WindowModel.js" as WindowModel
+
+TestCase {
+  name: "WindowModel"
+
+  function client(address, grouped, acceptsInput, focusHistoryID, extra) {
+    var ipc = {
+      address: address,
+      grouped: grouped || [],
+      hidden: false,
+      visible: acceptsInput === true,
+      acceptsInput: acceptsInput === true,
+      focusHistoryID: isFinite(focusHistoryID) ? focusHistoryID : (acceptsInput === true ? 0 : 5),
+      at: [12, 47],
+      size: [900, 1000],
+      floating: false
+    }
+    extra = extra || {}
+    for (var key in extra) ipc[key] = extra[key]
+    return { address: address, title: extra.title || address, lastIpcObject: ipc }
+  }
+
+  function addresses(clients) {
+    return clients.map(function(value) { return value.address })
+  }
+
+  function test_twoNormalWindowsRemainVisible() {
+    var values = [client("0x1", [], true, 0), client("0x2", [], true, 1)]
+    compare(addresses(WindowModel.visibleWorkspaceWindows(values)), ["0x1", "0x2"])
+  }
+
+  function test_twoMemberGroupUsesActiveMember() {
+    var group = ["0x1", "0x2"]
+    var values = [client("0x1", group, false, 2), client("0x2", group, true, 0)]
+    compare(addresses(WindowModel.visibleWorkspaceWindows(values)), ["0x2"])
+  }
+
+  function test_switchingGroupMemberSwitchesResult() {
+    var group = ["0x1", "0x2"]
+    var first = client("0x1", group, true, 0)
+    var second = client("0x2", group, false, 1)
+    compare(addresses(WindowModel.visibleWorkspaceWindows([first, second])), ["0x1"])
+
+    first.lastIpcObject.acceptsInput = false
+    first.lastIpcObject.focusHistoryID = 1
+    second.lastIpcObject.acceptsInput = true
+    second.lastIpcObject.focusHistoryID = 0
+    compare(addresses(WindowModel.visibleWorkspaceWindows([first, second])), ["0x2"])
+  }
+
+  function test_hiddenStateDeprioritizesMinimizedGroupMember() {
+    var group = ["0x1", "0x2"]
+    var first = client("0x1", group, true, 0, { hidden: true })
+    var second = client("0x2", group, false, 2, { hidden: false })
+    compare(addresses(WindowModel.visibleWorkspaceWindows([first, second])), ["0x2"])
+  }
+
+  function test_activeWindowAddressWinsOverStaleFlags() {
+    var group = ["0x1", "0x2"]
+    var first = client("0x1", group, true, 0)
+    var second = client("0x2", group, false, 1)
+    compare(addresses(WindowModel.visibleWorkspaceWindows([first, second], "0x2")), ["0x2"])
+  }
+
+  function test_threeMemberGroupIncludesExactlyOne() {
+    var group = ["0x1", "0x2", "0x3"]
+    var result = WindowModel.visibleWorkspaceWindows([
+      client("0x1", group, false, 3),
+      client("0x2", group, true, 0),
+      client("0x3", group, false, 5)
+    ])
+    compare(addresses(result), ["0x2"])
+  }
+
+  function test_twoIndependentGroups() {
+    var one = ["0x1", "0x2"]
+    var two = ["0x3", "0x4"]
+    var result = WindowModel.visibleWorkspaceWindows([
+      client("0x1", one, true, 0), client("0x2", one, false, 2),
+      client("0x3", two, false, 3), client("0x4", two, true, 1)
+    ])
+    compare(addresses(result), ["0x1", "0x4"])
+  }
+
+  function test_groupAndNormalWindow() {
+    var group = ["0x1", "0x2"]
+    var result = WindowModel.visibleWorkspaceWindows([
+      client("0x1", group, false, 2),
+      client("0x2", group, true, 0),
+      client("0x3", [], true, 1)
+    ])
+    compare(addresses(result), ["0x2", "0x3"])
+  }
+
+  function test_unrelatedNormalWindowsWithIdenticalGeometryAreNotDeduplicated() {
+    var first = client("0x1", [], true, 0, { at: [0, 0], size: [1920, 1080] })
+    var second = client("0x2", [], true, 1, { at: [0, 0], size: [1920, 1080] })
+    var result = WindowModel.visibleWorkspaceWindows([first, second])
+    compare(addresses(result), ["0x1", "0x2"])
+  }
+
+  function test_identicalGeometryGroupedMembersDoNotCover() {
+    var group = ["0x1", "0x2"]
+    var result = WindowModel.visibleWorkspaceWindows([
+      client("0x1", group, false, 1), client("0x2", group, true, 0)
+    ])
+    compare(result.length, 1)
+    compare(result[0].address, "0x2")
+    compare(result[0].lastIpcObject.at, [12, 47])
+    compare(result[0].lastIpcObject.size, [900, 1000])
+  }
+
+  function test_activeMemberCloses() {
+    var staleGroup = ["0x1", "0x2"]
+    var remaining = client("0x1", staleGroup, true, 0)
+    compare(addresses(WindowModel.visibleWorkspaceWindows([remaining])), ["0x1"])
+  }
+
+  function test_dissolvedGroupRestoresNormalWindows() {
+    var values = [client("0x1", [], true, 0), client("0x2", [], true, 1)]
+    compare(addresses(WindowModel.visibleWorkspaceWindows(values)), ["0x1", "0x2"])
+  }
+
+  function test_malformedMetadataDoesNotCrash() {
+    var malformed = [
+      { address: "not-an-address", lastIpcObject: { grouped: null } },
+      { address: "0x2", lastIpcObject: { grouped: [null, "bad"] } },
+      { address: "0x3" },
+      null
+    ]
+    compare(WindowModel.visibleWorkspaceWindows(malformed).length, 4)
+  }
+
+  function test_qtVariantStyleGroupedListIsRecognized() {
+    var grouped = { 0: "0x1", 1: "0x2", length: 2 }
+    var values = [client("0x1", [], false, 1), client("0x2", [], true, 0)]
+    values[0].lastIpcObject.grouped = grouped
+    values[1].lastIpcObject.grouped = grouped
+    compare(addresses(WindowModel.visibleWorkspaceWindows(values)), ["0x2"])
+  }
+
+  function test_missingInputFlagUsesFocusHistoryID() {
+    var group = ["0x1", "0x2"]
+    var first = client("0x1", group, false, 5, { acceptsInput: undefined })
+    var second = client("0x2", group, false, 1, { acceptsInput: undefined })
+    compare(addresses(WindowModel.visibleWorkspaceWindows([first, second])), ["0x2"])
+  }
+
+  function test_floatingGroupPreservesClientAndGeometry() {
+    var group = ["0x1", "0x2"]
+    var visible = client("0x2", group, true, 0, {
+      floating: true, at: [400, 225], size: [800, 450]
+    })
+    var result = WindowModel.visibleWorkspaceWindows([
+      client("0x1", group, false, 2), visible
+    ])
+    compare(result.length, 1)
+    verify(result[0] === visible)
+    compare(result[0].lastIpcObject.at, [400, 225])
+    compare(result[0].lastIpcObject.size, [800, 450])
+    compare(result[0].lastIpcObject.floating, true)
+  }
+
+  function test_partialOverlappingMetadataStillFormsOneGroup() {
+    var first = client("0x1", ["0x1", "0x2"], false, 3)
+    var second = client("0x2", ["0x1", "0x2", "0x3"], false, 2)
+    var third = client("0x3", ["0x2", "0x3"], true, 0)
+    compare(addresses(WindowModel.visibleWorkspaceWindows([first, second, third])), ["0x3"])
+  }
+
+  function test_addressNormalizationMatchesWithOrWithoutHexPrefix() {
+    var group = ["564bf618b650", "0x564bff177040"]
+    var first = client("564bf618b650", group, false, 2)
+    var second = client("564bff177040", group, true, 0)
+    compare(addresses(WindowModel.visibleWorkspaceWindows([first, second], "564bff177040")), ["564bff177040"])
+  }
+
+  // ── Structured preview descriptor tests (resolveWorkspacePreviews) ──────────
+
+  function test_resolveGroupModelRetainsEveryMember() {
+    var group = ["0x1", "0x2"]
+    var brave = client("0x1", group, false, 2, { title: "Brave" })
+    var foot = client("0x2", group, true, 0, { title: "foot" })
+
+    var previews = WindowModel.resolveWorkspacePreviews([brave, foot])
+    compare(previews.length, 1)
+    verify(previews[0].isGroup === true)
+    verify(previews[0].type === "group")
+    compare(previews[0].activeMember, foot)
+    compare(previews[0].toplevel, foot)
+    compare(previews[0].members.length, 2)
+    compare(previews[0].members[0].title, "Brave")
+    compare(previews[0].members[1].title, "foot")
+  }
+
+  function test_resolveGroupActiveMemberSwitching() {
+    var group = ["0x1", "0x2"]
+    var brave = client("0x1", group, false, 2, { title: "Brave" })
+    var foot = client("0x2", group, true, 0, { title: "foot" })
+
+    var previews1 = WindowModel.resolveWorkspacePreviews([brave, foot])
+    compare(previews1[0].activeMember, foot)
+
+    // Switch active tab to Brave
+    brave.lastIpcObject.acceptsInput = true
+    brave.lastIpcObject.focusHistoryID = 0
+    foot.lastIpcObject.acceptsInput = false
+    foot.lastIpcObject.focusHistoryID = 1
+
+    var previews2 = WindowModel.resolveWorkspacePreviews([brave, foot])
+    compare(previews2.length, 1)
+    verify(previews2[0].isGroup === true)
+    compare(previews2[0].activeMember, brave)
+    compare(previews2[0].toplevel, brave)
+    compare(previews2[0].members.length, 2)
+  }
+
+  function test_resolveThreeMemberGroup() {
+    var group = ["0x1", "0x2", "0x3"]
+    var brave = client("0x1", group, false, 3, { title: "Brave" })
+    var foot = client("0x2", group, true, 0, { title: "foot" })
+    var ghostty = client("0x3", group, false, 4, { title: "Ghostty" })
+
+    var previews = WindowModel.resolveWorkspacePreviews([brave, foot, ghostty])
+    compare(previews.length, 1)
+    verify(previews[0].isGroup === true)
+    compare(previews[0].activeMember, foot)
+    compare(previews[0].members.length, 3)
+  }
+
+  function test_resolveMixedWorkspaceNormalAndGroup() {
+    var group = ["0x1", "0x2"]
+    var brave = client("0x1", group, false, 2, { title: "Brave" })
+    var foot = client("0x2", group, true, 0, { title: "foot" })
+    var ghostty = client("0x3", [], true, 1, { title: "Ghostty" })
+    var files = client("0x4", [], true, 3, { title: "Files" })
+
+    var previews = WindowModel.resolveWorkspacePreviews([brave, foot, ghostty, files])
+    // 4 clients total, 1 group + 2 normal = 3 spatial previews
+    compare(previews.length, 3)
+    verify(previews[0].isGroup === true)
+    compare(previews[0].members.length, 2)
+    verify(previews[1].isGroup === false)
+    compare(previews[1].toplevel, ghostty)
+    verify(previews[2].isGroup === false)
+    compare(previews[2].toplevel, files)
+  }
+
+  function test_resolveGroupCollapsingFromTwoToOne() {
+    // When one member of a 2-member group closes, remaining member becomes normal window
+    var single = client("0x1", ["0x1"], true, 0, { title: "Remaining" })
+    var previews = WindowModel.resolveWorkspacePreviews([single])
+    compare(previews.length, 1)
+    verify(previews[0].isGroup === false)
+    verify(previews[0].type === "window")
+    compare(previews[0].toplevel, single)
+  }
+
+  function test_resolveGroupDissolution() {
+    var brave = client("0x1", [], true, 0, { title: "Brave" })
+    var foot = client("0x2", [], true, 1, { title: "foot" })
+
+    var previews = WindowModel.resolveWorkspacePreviews([brave, foot])
+    compare(previews.length, 2)
+    verify(previews[0].isGroup === false)
+    verify(previews[1].isGroup === false)
+  }
+
+  function test_resolveTwoIndependentGroups() {
+    var group1 = ["0x1", "0x2"]
+    var group2 = ["0x3", "0x4"]
+    var a = client("0x1", group1, true, 0)
+    var b = client("0x2", group1, false, 2)
+    var c = client("0x3", group2, false, 3)
+    var d = client("0x4", group2, true, 1)
+
+    var previews = WindowModel.resolveWorkspacePreviews([a, b, c, d])
+    compare(previews.length, 2)
+    verify(previews[0].isGroup === true)
+    compare(previews[0].activeMember, a)
+    compare(previews[0].members.length, 2)
+    verify(previews[1].isGroup === true)
+    compare(previews[1].activeMember, d)
+    compare(previews[1].members.length, 2)
+  }
+}

--- a/tests/tst_workspaceoverview_integration.qml
+++ b/tests/tst_workspaceoverview_integration.qml
@@ -12,8 +12,34 @@ TestCase {
     return request.responseText
   }
 
+  function workspaceCardSource() {
+    var request = new XMLHttpRequest()
+    request.open("GET", Qt.resolvedUrl("../WorkspaceCard.qml"), false)
+    request.send()
+    verify(request.status === 0 || request.status === 200)
+    return request.responseText
+  }
+
   function test_blurNamespaceRemainsStable() {
     var source = workspaceOverviewSource()
     verify(/WlrLayershell\.namespace\s*:\s*"omarchy-workspace-overview"/.test(source))
+  }
+
+  function test_keyboardFocusRemainsExclusive() {
+    var source = workspaceOverviewSource()
+    verify(/WlrLayershell\.keyboardFocus\s*:\s*WlrKeyboardFocus\.Exclusive/.test(source))
+  }
+
+  function test_groupModelRefreshesAfterIpcObjectChanges() {
+    var source = workspaceCardSource()
+    verify(/onLastIpcObjectChanged\s*\(\)\s*\{\s*root\.toplevelRevision\+\+\s*\}/.test(source))
+    verify(/onActiveToplevelChanged\s*\(\)\s*\{\s*root\.toplevelRevision\+\+\s*\}/.test(source))
+    verify(/WindowModel\.resolveWorkspacePreviews/.test(source))
+  }
+
+  function test_groupEventsUseExistingToplevelRefreshPath() {
+    var source = workspaceOverviewSource()
+    verify(/name\.indexOf\("group"\)\s*!==\s*-1/.test(source))
+    verify(/name\.indexOf\("group"\)[\s\S]*Hyprland\.refreshToplevels\(\)/.test(source))
   }
 }


### PR DESCRIPTION
## Summary

Hyprland grouped/tabbed windows now render as a single spatial container at their true compositor geometry with all group members represented in a compact top tab strip, while streaming live screencopy exclusively for the active group member.

## Root cause

In Hyprland, all windows in a grouped/tabbed container share the exact same spatial geometry coordinates. Mirador previously treated each client as an independent spatial preview, instantiating separate ScreencopyView delegates at identical coordinates. Because every group member was added to the workspace preview repeater, whichever client appeared later in the collection was rendered on top in the scene graph, visually covering the active group member.

## Fix

- **Normalized Hyprland addresses**: All addresses across `toplevel.address`, `lastIpcObject.address`, and `lastIpcObject.grouped` are normalized to lowercase `0x`-prefixed hex strings.
- **Group connected-component resolution**: Disjoint-set union is used in `WindowModel.js` to reliably discover grouped window clusters even during transitional or asymmetric IPC states.
- **Retained `members[]`**: Group containers retain the full array of member toplevels, their titles, application IDs, and desktop entry icons.
- **Active representative selection**: The frontmost group tab is determined using current Hyprland state (`Hyprland.activeToplevel` match, `acceptsInput: true`, and lowest `focusHistoryID`) rather than geometry deduplication.
- **Single spatial delegate per group**: `WorkspaceCard.qml` instantiates exactly one `WindowPreview` delegate per group container.
- **Group tab UI**: `WindowPreview.qml` renders a compact group tab strip along the top of grouped containers with active tab styling. Clicking a group tab activates that specific member in Hyprland (`hl.dsp.focus({ window = "address:" + address })`).
- **Reactive updates**: Listens to compositor events (`window*`, `group*`, `workspace*`, `fullscreen`, `changefloatingmode`, `focusedmon`), `onActiveToplevelChanged`, and `onLastIpcObjectChanged` to live-update group tabs and screencopy capture when the active member or group membership changes.

## Testing

Ran full test suite:
```bash
qmltestrunner -input tests/
```
Totals: **56 passed, 0 failed, 0 skipped, 0 blacklisted**

Manual verification in running session:
- **2-member group**: Rendered as 1 spatial container with 2 tabs; active member screencopy displayed.
- **Switching active member while Mirador is open**: Preview live-swapped screencopy and tab styling instantly.
- **3-member group**: Tab strip represented all 3 members and 1 active screencopy.
- **Mixed grouped + ungrouped workspace**: 4 clients (1 group of 2 + 2 ungrouped) rendered as 3 spatial preview containers.
- **Closing active member & removing member**: Tab strip shrunk gracefully without breaking live capture.
- **Dissolving group**: Former group members immediately returned to independent normal spatial previews.
- **Group collapsing to 1 member**: Gracefully reverted to standard single-window preview title pill.

## Closes

Closes #1