### PR TITLE
fix: release screencopy source while overview is hidden

### DIFF
--- a/WindowPreview.qml
+++ b/WindowPreview.qml
@@ -106,7 +106,7 @@ Rectangle {
     ScreencopyView {
       id: preview
       anchors.centerIn: parent
-      captureSource: root.waylandToplevel
+      captureSource: root.liveCaptureEnabled ? root.waylandToplevel : null
       live: root.liveCaptureEnabled
       paintCursor: false
       width: {

--- a/tests/tst_windowpreview_security.qml
+++ b/tests/tst_windowpreview_security.qml
@@ -36,6 +36,11 @@ TestCase {
     verify(/text\s*:\s*root\.title\s*\n\s*textFormat\s*:\s*Text\.PlainText/.test(source))
   }
 
+  function test_hiddenPreviewReleasesCaptureSource() {
+    var source = windowPreviewSource()
+    verify(/captureSource\s*:\s*root\.liveCaptureEnabled\s*\?\s*root\.waylandToplevel\s*:\s*null/.test(source))
+  }
+
   function test_hostileTitlesRemainPlainText() {
     compare(securedText.textFormat, Text.PlainText)
 


### PR DESCRIPTION
Mirador remains loaded when its overview is hidden, but `ScreencopyView` retains its toplevel capture source even when live capture is disabled. If the monitor has disconnected, a subsequent capture request causes Hyprland to crash in `CScreenshareSession::init()`.

I experienced this crash twice on a single-monitor system after physically powering off the display. The related Hyprland report is [discussion #16127](https://github.com/hyprwm/Hyprland/discussions/16127).

This change clears `captureSource` while live capture is disabled and restores it when the overview becomes active.

Testing: 61 QML tests passed.