### PR TITLE
fix(preview): snap preview geometry to physical pixels and eliminate fractional rescale blur

### DIFF
--- a/WindowGeometry.js
+++ b/WindowGeometry.js
@@ -9,6 +9,15 @@ function clamp(value, minimum, maximum) {
   return Math.max(minimum, Math.min(value, maximum))
 }
 
+// Snap a coordinate or dimension to the nearest physical device pixel to ensure
+// crisp rendering and eliminate bilinear subpixel interpolation blur.
+function snapToDevicePixels(value, dpr) {
+  var num = finiteNumber(value)
+  if (isNaN(num)) return 0
+  var scale = (finiteNumber(dpr) > 0) ? Number(dpr) : 1.0
+  return Math.round(num * scale) / scale
+}
+
 // Return a nearly edge-to-edge canvas without ever producing negative sizes
 // on extremely small cards. Workspace badges and window title pills overlay
 // this rectangle and therefore do not reduce it.

--- a/WindowPreview.qml
+++ b/WindowPreview.qml
@@ -101,22 +101,13 @@ Rectangle {
   Item {
     id: imageArea
     anchors.fill: parent
-    clip: true
 
     ScreencopyView {
       id: preview
-      anchors.centerIn: parent
+      anchors.fill: parent
       captureSource: root.liveCaptureEnabled ? root.waylandToplevel : null
       live: root.liveCaptureEnabled
       paintCursor: false
-      width: {
-        if (!hasContent || sourceSize.width <= 0 || sourceSize.height <= 0) return parent.width
-        return Math.min(parent.width, parent.height * sourceSize.width / sourceSize.height)
-      }
-      height: {
-        if (!hasContent || sourceSize.width <= 0 || sourceSize.height <= 0) return parent.height
-        return Math.min(parent.height, parent.width * sourceSize.height / sourceSize.width)
-      }
       visible: hasContent
     }
 

--- a/WorkspaceCard.qml
+++ b/WorkspaceCard.qml
@@ -126,12 +126,7 @@ BorderSurface {
     : (occupied ? Util.alpha(Color.menu.background, 0.96) : Util.alpha(Color.menu.background, 0.88))
   borderSpec: Border.none()
   clip: true
-  scale: (root.isCurrent || root.highlighted) ? 1.008 : 1.0
   opacity: root.cardOpacity
-
-  Behavior on scale {
-    NumberAnimation { duration: 120; easing.type: Easing.OutQuad }
-  }
 
   Behavior on opacity {
     NumberAnimation { duration: 120; easing.type: Easing.OutQuad }
@@ -277,10 +272,14 @@ BorderSurface {
             : WindowGeometry.fallbackGeometry(index, root.windowCount,
               spatialPreview.width, spatialPreview.height, root.previewSpacing)
 
-          x: displayGeometry.x
-          y: displayGeometry.y
-          width: Math.max(1, displayGeometry.width)
-          height: Math.max(1, displayGeometry.height)
+          readonly property real dpr: (targetMonitor && targetMonitor.scale > 0)
+            ? targetMonitor.scale
+            : ((targetScreen && targetScreen.devicePixelRatio) ? targetScreen.devicePixelRatio : 1.0)
+
+          x: WindowGeometry.snapToDevicePixels(displayGeometry.x, dpr)
+          y: WindowGeometry.snapToDevicePixels(displayGeometry.y, dpr)
+          width: Math.max(1, WindowGeometry.snapToDevicePixels(displayGeometry.width, dpr))
+          height: Math.max(1, WindowGeometry.snapToDevicePixels(displayGeometry.height, dpr))
           z: index + 1
           toplevel: previewToplevel
           isGroup: Boolean(modelData && modelData.isGroup)

--- a/tests/tst_windowgeometry.qml
+++ b/tests/tst_windowgeometry.qml
@@ -536,4 +536,28 @@ TestCase {
     // Right from 1 should wrap to workspace 0
     compare(WindowGeometry.cyclicCardMove(mixed, 1, 1, 0), 0)
   }
+
+  function test_snapToDevicePixels() {
+    // 1x DPR standard screen: snaps to whole integers
+    compare(WindowGeometry.snapToDevicePixels(10.2, 1), 10)
+    compare(WindowGeometry.snapToDevicePixels(10.7, 1), 11)
+    compare(WindowGeometry.snapToDevicePixels(10.5, 1), 11)
+
+    // 2x DPR HiDPI screen: snaps to 0.5 physical boundaries
+    compare(WindowGeometry.snapToDevicePixels(10.2, 2), 10)
+    compare(WindowGeometry.snapToDevicePixels(10.3, 2), 10.5)
+    compare(WindowGeometry.snapToDevicePixels(10.7, 2), 10.5)
+    compare(WindowGeometry.snapToDevicePixels(10.8, 2), 11)
+
+    // 1.5x DPR fractional scale: snaps to multiples of 1/1.5 = 2/3
+    fuzzyCompare(WindowGeometry.snapToDevicePixels(10.0, 1.5), 10.0)
+    fuzzyCompare(WindowGeometry.snapToDevicePixels(10.33, 1.5), 10.0)
+    fuzzyCompare(WindowGeometry.snapToDevicePixels(10.4, 1.5), 10.66667)
+
+    // Fallbacks on invalid DPR or NaN
+    compare(WindowGeometry.snapToDevicePixels(15.4, 0), 15)
+    compare(WindowGeometry.snapToDevicePixels(15.4, -1), 15)
+    compare(WindowGeometry.snapToDevicePixels(15.4, null), 15)
+    compare(WindowGeometry.snapToDevicePixels(NaN, 1), 0)
+  }
 }


### PR DESCRIPTION
## Summary

This PR addresses the soft, smeared, and blurry window/workspace preview rendering in Mirador, bringing visual quality and edge sharpness up to GNOME/KDE overview standards.

## Root Causes Identified
1. **Unnecessary Rescaling Matrix (`scale: 1.008`) on WorkspaceCard:**
   - Active and hovered workspace cards were applying an animated `scale: 1.008`. In Qt Quick's Scene Graph, this inserted a `QSGTransformNode` that magnified already downscaled window textures by 0.8%, destroying pixel grid alignment and subjecting every single preview texel to continuous bilinear interpolation.
2. **Fractional Coordinates & Subpixel Offsets:**
   - Window preview geometries calculated floating-point `x`, `y`, `width`, and `height` values, causing quad vertices in the scene graph to land across physical pixel boundaries.
3. **Double Aspect Ratio Scaling & Subpixel Centering in ScreencopyView:**
   - `WindowPreview.qml` was computing custom aspect ratios in JavaScript and centering the preview (`anchors.centerIn: parent`). Quickshell's internal C++ implementation (`WlBufferQSGDisplayNode::setRect`) already scales to keep aspect ratio and centers within its bounding rect, causing compounded fractional subpixel offsets.

## Key Changes
- **`WorkspaceCard.qml`:**
  - Removed `scale: 1.008` and its `Behavior on scale`. Card hierarchy and focus are already clearly communicated via accent border, background opacity, badge styling, and workspace dimming.
  - Aligned window preview `x`, `y`, `width`, and `height` to physical device pixels using `WindowGeometry.snapToDevicePixels(val, dpr)`.
- **`WindowGeometry.js`:**
  - Added `snapToDevicePixels(value, dpr)` to calculate clean pixel snapping across 1x displays, HiDPI (2x), and fractional scaling factors (e.g. 1.25x, 1.5x).
- **`WindowPreview.qml`:**
  - Replaced JavaScript aspect-ratio bindings and `anchors.centerIn: parent` with `anchors.fill: parent` to allow Quickshell's native C++ `WlBufferQSGDisplayNode` to handle aspect-ratio preservation directly without intermediate fractional shifts.
  - Removed redundant nested `clip: true` from `imageArea`.
- **`tests/tst_windowgeometry.qml`:**
  - Added comprehensive unit tests for `snapToDevicePixels` across standard, HiDPI, fractional scaling, and boundary/fallback conditions.

## Verification
- All 51 unit tests pass (`qmltestrunner`).
- Visual comparison with `grim` screenshots confirms terminal text glyphs, browser text, and window borders are sharp with no smearing or bilinear phase blur.