### PR TITLE
feat(overview): adaptive equal-size row packing for normal overview mode

### DIFF
--- a/WindowGeometry.js
+++ b/WindowGeometry.js
@@ -36,68 +36,223 @@ function insetGeometry(width, height, requestedInset) {
   }
 }
 
-// Fit a complete workspace grid inside the bar-aware usable rectangle and
-// return offsets that center it exactly. Trying every possible column count
-// avoids aspect-ratio heuristics that become unbalanced for counts such as six
-// or on portrait/ultrawide outputs.
+// Helper to generate balanced row distributions for count items into R rows.
+// For example, count = 5, R = 2 produces [[3, 2], [2, 3]].
+function getBalancedRowDistributions(count, R) {
+  var kHigh = Math.ceil(count / R)
+  var kLow = Math.floor(count / R)
+  var h = count - kLow * R
+  var l = R - h
+
+  if (h === 0) {
+    var single = []
+    for (var i = 0; i < R; i++) single.push(kLow)
+    return [single]
+  }
+
+  // Priority order:
+  // 1. Top-heavy: h high rows, then l low rows (e.g. [2, 1], [3, 2], [3, 2, 2])
+  // 2. Symmetric / centered distributions
+  // 3. Bottom-heavy: l low rows, then h high rows (e.g. [1, 2], [2, 3], [2, 2, 3])
+  var results = []
+  var seen = {}
+
+  function permute(remainingHigh, remainingLow, current) {
+    if (remainingHigh === 0 && remainingLow === 0) {
+      var key = current.join(",")
+      if (!seen[key]) {
+        seen[key] = true
+        results.push(current.slice())
+      }
+      return
+    }
+    if (remainingHigh > 0) {
+      current.push(kHigh)
+      permute(remainingHigh - 1, remainingLow, current)
+      current.pop()
+    }
+    if (remainingLow > 0) {
+      current.push(kLow)
+      permute(remainingHigh, remainingLow - 1, current)
+      current.pop()
+    }
+  }
+
+  permute(h, l, [])
+  return results
+}
+
+// Adaptive equal-size overview layout solver for Normal overview mode.
+// Solves: "What is the largest common workspace-card size that allows all workspaces to fit on screen?"
+// Subject to:
+// - every card has the same width
+// - every card has the same height
+// - workspace aspect ratio is preserved
+// - all cards remain inside the usable viewport
+// - reasonable spacing remains
+// - rows are centered independently
+// - no overlap
+// - no fake empty workspace cells
 function overviewGridGeometry(count, areaWidth, areaHeight, aspectRatio,
                               maximumCardWidth, spacing) {
+  var effectiveSpacing = spacing
+  var effectiveMaxWidth = maximumCardWidth
+  if (arguments.length === 5) {
+    effectiveSpacing = maximumCardWidth
+    effectiveMaxWidth = null
+  }
+
   var safeCount = Math.max(0, Math.floor(finiteNumber(count) || 0))
   var safeWidth = Math.max(1, finiteNumber(areaWidth) || 1)
   var safeHeight = Math.max(1, finiteNumber(areaHeight) || 1)
   var safeAspect = Math.max(0.01, finiteNumber(aspectRatio) || 1)
-  var safeMaximumWidth = Math.max(1, finiteNumber(maximumCardWidth) || safeWidth)
-  var gap = Math.max(0, finiteNumber(spacing) || 0)
+  var gap = Math.max(0, finiteNumber(effectiveSpacing) || 0)
+  var safeMaximumWidth = (effectiveMaxWidth !== undefined && effectiveMaxWidth !== null && finiteNumber(effectiveMaxWidth) > 0)
+    ? Math.max(1, finiteNumber(effectiveMaxWidth))
+    : safeWidth
 
   if (safeCount === 0) {
-    return { columns: 0, rows: 0, cardWidth: 0, cardHeight: 0,
-      gridWidth: 0, gridHeight: 0, x: safeWidth / 2, y: safeHeight / 2 }
+    return {
+      columns: 0,
+      rows: 0,
+      cardWidth: 0,
+      cardHeight: 0,
+      gridWidth: 0,
+      gridHeight: 0,
+      x: safeWidth / 2,
+      y: safeHeight / 2,
+      rowDistribution: [],
+      cards: []
+    }
+  }
+
+  if (safeCount === 1) {
+    var singleW = Math.min(safeMaximumWidth, safeWidth, safeHeight * safeAspect)
+    var singleH = singleW / safeAspect
+    var singleX = (safeWidth - singleW) / 2
+    var singleY = (safeHeight - singleH) / 2
+    return {
+      columns: 1,
+      rows: 1,
+      cardWidth: singleW,
+      cardHeight: singleH,
+      gridWidth: singleW,
+      gridHeight: singleH,
+      x: singleX,
+      y: singleY,
+      rowDistribution: [1],
+      cards: [{
+        index: 0,
+        x: singleX,
+        y: singleY,
+        width: singleW,
+        height: singleH,
+        row: 0,
+        col: 0
+      }]
+    }
   }
 
   var best = null
-  for (var columns = 1; columns <= safeCount; columns++) {
-    var rows = Math.ceil(safeCount / columns)
-    var widthAvailable = safeWidth - gap * (columns - 1)
-    var heightAvailable = safeHeight - gap * (rows - 1)
-    if (widthAvailable <= 0 || heightAvailable <= 0) continue
+  var targetAspect = safeWidth / safeHeight
 
-    var cardWidth = Math.min(
-      safeMaximumWidth,
-      widthAvailable / columns,
-      heightAvailable / rows * safeAspect)
-    if (!isFinite(cardWidth) || cardWidth <= 0) continue
+  // Evaluate candidate row counts from 1 up to safeCount
+  for (var R = 1; R <= safeCount; R++) {
+    var dists = getBalancedRowDistributions(safeCount, R)
+    for (var d = 0; d < dists.length; d++) {
+      var dist = dists[d]
+      var Cmax = 0
+      for (var k = 0; k < dist.length; k++) {
+        if (dist[k] > Cmax) Cmax = dist[k]
+      }
+      var widthAvailable = safeWidth - gap * (Cmax - 1)
+      var heightAvailable = safeHeight - gap * (R - 1)
+      if (widthAvailable <= 0 || heightAvailable <= 0) continue
 
-    var cardHeight = cardWidth / safeAspect
-    var gridWidth = cardWidth * columns + gap * (columns - 1)
-    var gridHeight = cardHeight * rows + gap * (rows - 1)
-    var candidate = {
-      columns: columns,
-      rows: rows,
-      cardWidth: cardWidth,
-      cardHeight: cardHeight,
-      gridWidth: gridWidth,
-      gridHeight: gridHeight,
-      x: (safeWidth - gridWidth) / 2,
-      y: (safeHeight - gridHeight) / 2
+      var cardW = Math.min(
+        safeMaximumWidth,
+        widthAvailable / Cmax,
+        (heightAvailable / R) * safeAspect)
+      if (!isFinite(cardW) || cardW <= 0) continue
+
+      var cardH = cardW / safeAspect
+      var cardArea = cardW * cardH
+      var gridW = Cmax * cardW + gap * (Cmax - 1)
+      var gridH = R * cardH + gap * (R - 1)
+      var gridAspect = gridW / gridH
+      var aspectDiff = Math.abs(gridAspect - targetAspect)
+
+      var candidate = {
+        columns: Cmax,
+        rows: R,
+        rowDistribution: dist,
+        cardWidth: cardW,
+        cardHeight: cardH,
+        cardArea: cardArea,
+        gridWidth: gridW,
+        gridHeight: gridH,
+        x: (safeWidth - gridW) / 2,
+        y: (safeHeight - gridH) / 2,
+        aspectDiff: aspectDiff
+      }
+
+      // Objective: largest common card area wins
+      if (!best || cardW > best.cardWidth + 0.001) {
+        best = candidate
+      } else if (Math.abs(cardW - best.cardWidth) <= 0.001) {
+        // Tie breakers:
+        // 1. Better screen shape match (aspectDiff)
+        // 2. Fewer rows for stable landscape layouts
+        if (candidate.aspectDiff < best.aspectDiff - 0.01) {
+          best = candidate
+        } else if (Math.abs(candidate.aspectDiff - best.aspectDiff) <= 0.01 && candidate.rows < best.rows) {
+          best = candidate
+        }
+      }
     }
-
-    // Largest readable cards win. For effectively equal sizes, prefer the
-    // arrangement closest to square, then fewer rows for stable landscape
-    // layouts.
-    var balance = Math.abs(columns - rows)
-    var bestBalance = best ? Math.abs(best.columns - best.rows) : Infinity
-    if (!best || cardWidth > best.cardWidth + 0.001
-        || (Math.abs(cardWidth - best.cardWidth) <= 0.001
-          && (balance < bestBalance
-            || (balance === bestBalance && rows < best.rows))))
-      best = candidate
   }
 
-  return best || { columns: 1, rows: safeCount, cardWidth: 1,
-    cardHeight: 1 / safeAspect, gridWidth: 1,
-    gridHeight: safeCount / safeAspect + gap * (safeCount - 1),
-    x: (safeWidth - 1) / 2,
-    y: (safeHeight - (safeCount / safeAspect + gap * (safeCount - 1))) / 2 }
+  if (!best) {
+    var fallbackDist = [safeCount]
+    var fallbackH = safeCount / safeAspect + gap * (safeCount - 1)
+    return {
+      columns: 1,
+      rows: safeCount,
+      cardWidth: 1,
+      cardHeight: 1 / safeAspect,
+      gridWidth: 1,
+      gridHeight: fallbackH,
+      x: (safeWidth - 1) / 2,
+      y: (safeHeight - fallbackH) / 2,
+      rowDistribution: fallbackDist,
+      cards: []
+    }
+  }
+
+  // Populate individual card geometries with independent row centering
+  var cards = []
+  var curY = best.y
+  var cardIdx = 0
+  for (var r = 0; r < best.rows; r++) {
+    var countInRow = best.rowDistribution[r]
+    var rowW = countInRow * best.cardWidth + gap * (countInRow - 1)
+    var rowX = (safeWidth - rowW) / 2
+    for (var c = 0; c < countInRow; c++) {
+      cards.push({
+        index: cardIdx++,
+        x: rowX + c * (best.cardWidth + gap),
+        y: curY,
+        width: best.cardWidth,
+        height: best.cardHeight,
+        row: r,
+        col: c
+      })
+    }
+    curY += best.cardHeight + gap
+  }
+  best.cards = cards
+
+  return best
 }
 
 // Hyprland reports client positions in global compositor coordinates. Monitor

--- a/WorkspaceOverview.qml
+++ b/WorkspaceOverview.qml
@@ -71,7 +71,7 @@ Item {
 
   readonly property var gridGeometry: WindowGeometry.overviewGridGeometry(
     cardCount, usableWidth, usableGridHeight, cardAspectRatio,
-    Style.space(520), gridSpacing)
+    gridSpacing)
   readonly property int columns: Math.max(1, gridGeometry.columns)
   readonly property int rows: Math.max(1, gridGeometry.rows)
   readonly property real cardWidth: Math.max(1, gridGeometry.cardWidth)
@@ -211,14 +211,38 @@ Item {
     return -1
   }
 
+  function normalCardGeom(idx) {
+    if (idx < 0 || !root.gridGeometry || !root.gridGeometry.cards) return null
+    if (idx < root.gridGeometry.cards.length) {
+      return root.gridGeometry.cards[idx]
+    }
+    return null
+  }
+
+  function slotWidth(idx) {
+    var nCard = root.normalCardGeom(idx)
+    if (nCard && nCard.width > 0) return Math.round(nCard.width)
+    return Math.round(root.cardWidth)
+  }
+
+  function slotHeight(idx) {
+    var nCard = root.normalCardGeom(idx)
+    if (nCard && nCard.height > 0) return Math.round(nCard.height)
+    return Math.round(root.cardHeight)
+  }
+
   function slotX(idx) {
     if (idx < 0) return 0
+    var nCard = root.normalCardGeom(idx)
+    if (nCard) return Math.round(root.usableX + nCard.x)
     var col = idx % root.columns
     return Math.round(root.usableX + root.gridGeometry.x + col * (root.cardWidth + root.gridSpacing))
   }
 
   function slotY(idx) {
     if (idx < 0) return 0
+    var nCard = root.normalCardGeom(idx)
+    if (nCard) return Math.round(root.usableGridY + nCard.y)
     var row = Math.floor(idx / root.columns)
     return Math.round(root.usableGridY + root.gridGeometry.y + row * (root.cardHeight + root.gridSpacing))
   }
@@ -227,8 +251,6 @@ Item {
     var items = []
     var isDragging = root.draggedToplevel !== null
     var wsIds = root.workspaceModel || []
-    var width = Math.round(root.cardWidth)
-    var height = Math.round(root.cardHeight)
 
     for (var i = 0; i < wsIds.length; i++) {
       var wsId = wsIds[i]
@@ -237,6 +259,8 @@ Item {
 
       var gx = root.slotX(slotIdx)
       var gy = root.slotY(slotIdx)
+      var width = root.slotWidth(slotIdx)
+      var height = root.slotHeight(slotIdx)
 
       items.push({
         index: slotIdx,
@@ -548,8 +572,8 @@ Item {
 
           x: root.slotX(slotIndex)
           y: root.slotY(slotIndex)
-          width: Math.round(root.cardWidth)
-          height: Math.round(root.cardHeight)
+          width: root.slotWidth(slotIndex)
+          height: root.slotHeight(slotIndex)
 
           overview: root
           workspaceId: modelData
@@ -581,8 +605,8 @@ Item {
 
           x: root.slotX(slotIndex)
           y: root.slotY(slotIndex)
-          width: Math.round(root.cardWidth)
-          height: Math.round(root.cardHeight)
+          width: root.slotWidth(slotIndex)
+          height: root.slotHeight(slotIndex)
 
           overview: root
           targetWorkspaceId: modelData

--- a/tests/tst_windowgeometry.qml
+++ b/tests/tst_windowgeometry.qml
@@ -560,4 +560,151 @@ TestCase {
     compare(WindowGeometry.snapToDevicePixels(15.4, null), 15)
     compare(WindowGeometry.snapToDevicePixels(NaN, 1), 0)
   }
+
+  function test_adaptiveOverview_workspaceCounts1to8() {
+    var width = 1880
+    var height = 1000
+    var aspect = 1.55
+    var spacing = 48
+
+    for (var count = 1; count <= 8; count++) {
+      var geom = WindowGeometry.overviewGridGeometry(count, width, height, aspect, spacing)
+      compare(geom.cards.length, count, "Generated cards count matches workspace count")
+
+      // 1. Verify every card has identical dimensions
+      for (var i = 0; i < count; i++) {
+        compare(geom.cards[i].width, geom.cardWidth, "Card " + i + " width matches cardWidth")
+        compare(geom.cards[i].height, geom.cardHeight, "Card " + i + " height matches cardHeight")
+      }
+
+      // 2. Verify aspect ratio is preserved
+      var cardAspect = geom.cardWidth / geom.cardHeight
+      fuzzyCompare(cardAspect, aspect, "Card aspect ratio preserved for count=" + count)
+
+      // 3. Verify all cards stay within bounds
+      for (var i = 0; i < count; i++) {
+        var card = geom.cards[i]
+        verify(card.x >= -0.001, "Card " + i + " x must be inside viewport")
+        verify(card.y >= -0.001, "Card " + i + " y must be inside viewport")
+        verify(card.x + card.width <= width + 0.001, "Card " + i + " right must be inside viewport")
+        verify(card.y + card.height <= height + 0.001, "Card " + i + " bottom must be inside viewport")
+      }
+
+      // 4. Verify no overlap between any two cards
+      for (var a = 0; a < count; a++) {
+        for (var b = a + 1; b < count; b++) {
+          var ca = geom.cards[a]
+          var cb = geom.cards[b]
+          var separated = (ca.x + ca.width <= cb.x + 0.001)
+            || (cb.x + cb.width <= ca.x + 0.001)
+            || (ca.y + ca.height <= cb.y + 0.001)
+            || (cb.y + cb.height <= ca.y + 0.001)
+          verify(separated, "Cards " + a + " and " + b + " must not overlap")
+        }
+      }
+
+      // 5. Verify every row is centered independently
+      var cardIdx = 0
+      for (var rowIdx = 0; rowIdx < geom.rows; rowIdx++) {
+        var numInRow = geom.rowDistribution[rowIdx]
+        var firstInRow = geom.cards[cardIdx]
+        var lastInRow = geom.cards[cardIdx + numInRow - 1]
+        var rowLeftMargin = firstInRow.x
+        var rowRightMargin = width - (lastInRow.x + lastInRow.width)
+        fuzzyCompare(rowLeftMargin, rowRightMargin, "Row " + rowIdx + " must be centered horizontally")
+        cardIdx += numInRow
+      }
+    }
+  }
+
+  function test_adaptiveOverview_threeWorkspacesComparison() {
+    var width = 1880
+    var height = 1000
+    var aspect = 1.55
+    var spacing = 48
+
+    // New adaptive solver
+    var adaptive = WindowGeometry.overviewGridGeometry(3, width, height, aspect, spacing)
+    compare(adaptive.cards.length, 3, "Exactly 3 cards rendered, no fake empty cells")
+    compare(adaptive.rows, 2, "3 cards arranged in 2 rows")
+    compare(adaptive.rowDistribution[0], 2, "Row 0 has 2 cards")
+    compare(adaptive.rowDistribution[1], 1, "Row 1 has 1 card")
+
+    // All 3 cards have identical dimensions
+    compare(adaptive.cards[0].width, adaptive.cardWidth)
+    compare(adaptive.cards[1].width, adaptive.cardWidth)
+    compare(adaptive.cards[2].width, adaptive.cardWidth)
+    compare(adaptive.cards[0].height, adaptive.cardHeight)
+    compare(adaptive.cards[1].height, adaptive.cardHeight)
+    compare(adaptive.cards[2].height, adaptive.cardHeight)
+
+    // The single card in row 1 is centered horizontally
+    var card2 = adaptive.cards[2]
+    var card2CenterX = card2.x + card2.width / 2
+    fuzzyCompare(card2CenterX, width / 2, "Row 1 single card must be centered horizontally at viewport center")
+
+    // Card 2 is centered between Card 0 and Card 1
+    var card0 = adaptive.cards[0]
+    var card1 = adaptive.cards[1]
+    var row0CenterX = (card0.x + card1.x + card1.width) / 2
+    fuzzyCompare(card2CenterX, row0CenterX, "Row 1 card center matches Row 0 center")
+
+    // Compare with old rigid grid with 520 cap
+    var oldRigid = WindowGeometry.overviewGridGeometry(3, width, height, aspect, 520, spacing)
+    compare(oldRigid.cardWidth, 520, "Old rigid grid capped cards at 520")
+    verify(adaptive.cardWidth > oldRigid.cardWidth * 1.35, "Adaptive card width is >35% larger than old rigid 520 capped grid")
+  }
+
+  function test_adaptiveOverview_viewportShapes() {
+    var spacing = 48
+
+    // 1. 16:9 widescreen
+    var w16_9 = WindowGeometry.overviewGridGeometry(3, 1880, 1000, 1.7778, spacing)
+    compare(w16_9.rowDistribution[0], 2)
+    compare(w16_9.rowDistribution[1], 1)
+
+    // 2. 16:10
+    var w16_10 = WindowGeometry.overviewGridGeometry(3, 1880, 1120, 1.6, spacing)
+    compare(w16_10.rowDistribution[0], 2)
+    compare(w16_10.rowDistribution[1], 1)
+
+    // 3. Ultrawide (3440x1440)
+    var uw = WindowGeometry.overviewGridGeometry(2, 3400, 1360, 2.38, spacing)
+    compare(uw.rows, 1, "Ultrawide places 2 workspaces side by side")
+    compare(uw.rowDistribution[0], 2)
+
+    // 4. Portrait (1080x1920)
+    var portrait = WindowGeometry.overviewGridGeometry(2, 1040, 1880, 0.56, spacing)
+    compare(portrait.rows, 2, "Portrait places 2 workspaces vertically [1, 1]")
+    compare(portrait.rowDistribution[0], 1)
+    compare(portrait.rowDistribution[1], 1)
+    compare(portrait.cards[0].width, portrait.cards[1].width)
+    compare(portrait.cards[0].height, portrait.cards[1].height)
+
+    // Verify portrait 5 workspaces uses 3 rows [2, 2, 1]
+    var p5 = WindowGeometry.overviewGridGeometry(5, 1040, 1880, 0.56, spacing)
+    compare(p5.rows, 3)
+    compare(p5.rowDistribution[0], 2)
+    compare(p5.rowDistribution[1], 2)
+    compare(p5.rowDistribution[2], 1)
+  }
+
+  function test_adaptiveOverview_selectionDoesNotAffectGeometry() {
+    var width = 1880
+    var height = 1000
+    var aspect = 1.55
+    var spacing = 48
+
+    // Normal mode overviewGridGeometry is deterministic and independent of selection
+    var g1 = WindowGeometry.overviewGridGeometry(5, width, height, aspect, spacing)
+    var g2 = WindowGeometry.overviewGridGeometry(5, width, height, aspect, spacing)
+    compare(g1.cardWidth, g2.cardWidth)
+    compare(g1.cardHeight, g2.cardHeight)
+    for (var i = 0; i < 5; i++) {
+      compare(g1.cards[i].x, g2.cards[i].x)
+      compare(g1.cards[i].y, g2.cards[i].y)
+      compare(g1.cards[i].width, g2.cards[i].width)
+      compare(g1.cards[i].height, g2.cards[i].height)
+    }
+  }
 }

--- a/tests/tst_workspaceoverview_integration.qml
+++ b/tests/tst_workspaceoverview_integration.qml
@@ -289,4 +289,37 @@ TestCase {
     verify(/WindowGeometry\.cyclicCardMove/.test(source))
     verify(/isInsertion\s*:\s*false/.test(source))
   }
+
+  function test_adaptiveOverviewNormalModeIntegration() {
+    var source = workspaceOverviewSource()
+
+    // 1. Grid geometry without 520px cap
+    verify(/overviewGridGeometry\(\s*cardCount,\s*usableWidth,\s*usableGridHeight,\s*cardAspectRatio,\s*gridSpacing\)/.test(source),
+      "WorkspaceOverview must invoke overviewGridGeometry without hardcoded 520px cap")
+
+    // 2. normalCardGeom helper defined and used
+    verify(/function\s+normalCardGeom\(idx\)/.test(source),
+      "WorkspaceOverview must define normalCardGeom helper")
+
+    var slotXMatch = source.match(/function\s+slotX\(idx\)[\s\S]*?\n  \}/)
+    verify(slotXMatch && /normalCardGeom/.test(slotXMatch[0]),
+      "slotX must query normalCardGeom in normal overview mode")
+
+    var slotYMatch = source.match(/function\s+slotY\(idx\)[\s\S]*?\n  \}/)
+    verify(slotYMatch && /normalCardGeom/.test(slotYMatch[0]),
+      "slotY must query normalCardGeom in normal overview mode")
+
+    var slotWMatch = source.match(/function\s+slotWidth\(idx\)[\s\S]*?\n  \}/)
+    verify(slotWMatch && /normalCardGeom/.test(slotWMatch[0]),
+      "slotWidth must query normalCardGeom in normal overview mode")
+
+    var slotHMatch = source.match(/function\s+slotHeight\(idx\)[\s\S]*?\n  \}/)
+    verify(slotHMatch && /normalCardGeom/.test(slotHMatch[0]),
+      "slotHeight must query normalCardGeom in normal overview mode")
+
+    // 3. Invariant: gridGeometry has NO dependency on selectedCardIndex
+    var gridGeomDecl = source.match(/readonly\s+property\s+var\s+gridGeometry\s*:\s*WindowGeometry\.overviewGridGeometry[\s\S]*?\)/)
+    verify(gridGeomDecl && !/selectedCardIndex/.test(gridGeomDecl[0]),
+      "gridGeometry must never depend on selectedCardIndex (selection must not alter Normal mode geometry)")
+  }
 }


### PR DESCRIPTION
## Summary
Adaptive multi-row balanced partition for Normal overview mode, removing the rigid 2x2 grid and hardcoded 520px card width cap.

## Key Changes
- Implement `WindowGeometry.overviewGridGeometry(count, availableWidth, availableHeight, cardAspectRatio, spacing)` to calculate optimal balanced row distributions across any workspace count.
- Update `WorkspaceOverview.qml` to bind card slot geometry dynamically to `normalCardGeom(idx)`.
- Ensure all workspace cards remain equal-sized peers in Normal mode, independent of selection.
- Add unit and integration tests covering row distributions, aspect-ratio preservation, and deterministic geometry.