### PR TITLE
feat(overview): add focused workspace overview mode with single vertical scrollable rail

### DIFF
--- a/WindowGeometry.js
+++ b/WindowGeometry.js
@@ -255,6 +255,123 @@ function overviewGridGeometry(count, areaWidth, areaHeight, aspectRatio,
   return best
 }
 
+// Fit a focused workspace layout where the primary selected workspace occupies
+// the majority of the screen (65-75% area), and remaining workspaces form an
+// adaptive secondary rail/grid on the right.
+function focusedOverviewGeometry(count, primaryIndex, areaWidth, areaHeight,
+                                 aspectRatio, spacing) {
+  var safeCount = Math.max(0, Math.floor(finiteNumber(count) || 0))
+  var safeWidth = Math.max(1, finiteNumber(areaWidth) || 1)
+  var safeHeight = Math.max(1, finiteNumber(areaHeight) || 1)
+  var safeAspect = Math.max(0.01, finiteNumber(aspectRatio) || 1)
+  var gap = Math.max(0, finiteNumber(spacing) || 0)
+  var primIdx = safeCount > 0 ? Math.max(0, Math.min(safeCount - 1, Math.floor(finiteNumber(primaryIndex) || 0))) : 0
+
+  if (safeCount === 0) {
+    return { primaryIndex: -1, cards: [] }
+  }
+
+  if (safeCount === 1) {
+    var singleW = Math.min(safeWidth, safeHeight * safeAspect)
+    var singleH = singleW / safeAspect
+    return {
+      primaryIndex: 0,
+      cards: [{
+        index: 0,
+        isPrimary: true,
+        x: (safeWidth - singleW) / 2,
+        y: (safeHeight - singleH) / 2,
+        width: singleW,
+        height: singleH
+      }]
+    }
+  }
+
+  var secCount = safeCount - 1
+  // Single vertical rail layout:
+  // Primary card targets 72-76% of usable width (capped by aspect ratio & safeHeight).
+  // The secondary rail occupies the remaining horizontal width as a single column.
+  var primRatio = 0.74
+  var primW = Math.min(safeWidth * primRatio, safeHeight * safeAspect)
+  var primH = primW / safeAspect
+  if (primH > safeHeight) {
+    primH = safeHeight
+    primW = primH * safeAspect
+  }
+
+  var secAvailW = safeWidth - primW - gap
+  // Enforce sensible minimum secondary card width/height
+  var minSecW = Math.min(220, safeWidth * 0.22)
+  if (secAvailW < minSecW && safeWidth > minSecW + 200) {
+    secAvailW = minSecW
+    primW = Math.min(safeWidth - secAvailW - gap, safeHeight * safeAspect)
+    primH = primW / safeAspect
+  }
+
+  var secCardW = Math.max(1, secAvailW)
+  var secCardH = Math.max(1, secCardW / safeAspect)
+
+  var totalW = primW + gap + secCardW
+  var startX = (safeWidth - totalW) / 2
+  var primY = (safeHeight - primH) / 2
+
+  var secXStart = startX + primW + gap
+
+  // Total content height of the secondary column
+  var totalSecContentH = secCount > 0 ? (secCardH * secCount + gap * (secCount - 1)) : 0
+  var railVisibleH = safeHeight
+
+  // If content fits within safeHeight, center it vertically in the rail;
+  // otherwise, start at 0 so it scrolls downward.
+  var secContentStartY = totalSecContentH <= safeHeight ? (safeHeight - totalSecContentH) / 2 : 0
+
+  var cards = []
+  for (var i = 0; i < safeCount; i++) {
+    cards.push(null)
+  }
+
+  cards[primIdx] = {
+    index: primIdx,
+    isPrimary: true,
+    x: startX,
+    y: primY,
+    width: primW,
+    height: primH,
+    railContentY: 0
+  }
+
+  var secIdx = 0
+  for (var j = 0; j < safeCount; j++) {
+    if (j === primIdx) continue
+    var contentY = secContentStartY + secIdx * (secCardH + gap)
+    cards[j] = {
+      index: j,
+      isPrimary: false,
+      x: secXStart,
+      y: contentY,
+      width: secCardW,
+      height: secCardH,
+      railIndex: secIdx,
+      railContentY: contentY
+    }
+    secIdx++
+  }
+
+  return {
+    primaryIndex: primIdx,
+    cards: cards,
+    primaryCard: cards[primIdx],
+    rail: {
+      x: secXStart,
+      y: 0,
+      width: secCardW,
+      height: railVisibleH,
+      contentHeight: totalSecContentH,
+      scrollNeeded: totalSecContentH > railVisibleH
+    }
+  }
+}
+
 // Hyprland reports client positions in global compositor coordinates. Monitor
 // x/y share that coordinate space, while the monitor mode dimensions need to
 // be converted to logical dimensions on scaled outputs. A matching QScreen is
@@ -489,6 +606,9 @@ function cyclicCardMove(items, currentIndex, dx, dy) {
     var cy = (it.centerY !== undefined && !isNaN(finiteNumber(it.centerY)))
       ? finiteNumber(it.centerY) : (y + h / 2)
 
+    var visualOrder = it.visualOrder !== undefined ? finiteNumber(it.visualOrder) : NaN
+    var isPrimary = Boolean(it.isPrimary)
+
     validItems.push({
       item: it,
       index: it.index !== undefined ? it.index : i,
@@ -497,7 +617,9 @@ function cyclicCardMove(items, currentIndex, dx, dy) {
       width: w,
       height: h,
       centerX: cx,
-      centerY: cy
+      centerY: cy,
+      visualOrder: isNaN(visualOrder) ? null : visualOrder,
+      isPrimary: isPrimary
     })
   }
 
@@ -516,69 +638,67 @@ function cyclicCardMove(items, currentIndex, dx, dy) {
     currentItem = validItems[0]
   }
 
-  // Sort primarily top-to-bottom, secondarily left-to-right
-  validItems.sort(function(a, b) {
-    if (Math.abs(a.centerY - b.centerY) > 1) {
-      return a.centerY - b.centerY
-    }
-    return a.centerX - b.centerX
-  })
-
-  // Group items into visual rows based on rendered vertical geometry
-  var rows = []
-  for (var i = 0; i < validItems.length; i++) {
-    var item = validItems[i]
-    var added = false
-    for (var r = 0; r < rows.length; r++) {
-      var rowCenterY = rows[r].centerY
-      var rowHeight = rows[r].height || item.height || 1
-      if (Math.abs(item.centerY - rowCenterY) < rowHeight * 0.5) {
-        rows[r].items.push(item)
-        var sumY = 0
-        for (var k = 0; k < rows[r].items.length; k++) sumY += rows[r].items[k].centerY
-        rows[r].centerY = sumY / rows[r].items.length
-        added = true
+  // 1. Horizontal navigation: one continuous global cycle
+  // If items provide explicit visualOrder, respect it for the global reading cycle.
+  if (dx !== 0) {
+    var hasExplicitOrder = true
+    for (var i = 0; i < validItems.length; i++) {
+      if (validItems[i].visualOrder === null) {
+        hasExplicitOrder = false
         break
       }
     }
-    if (!added) {
-      rows.push({
-        centerY: item.centerY,
-        height: item.height,
-        items: [item]
+
+    var orderedItems = []
+    if (hasExplicitOrder) {
+      orderedItems = validItems.slice().sort(function(a, b) {
+        return a.visualOrder - b.visualOrder
       })
+    } else {
+      // Sort primarily top-to-bottom, secondarily left-to-right
+      var geomSorted = validItems.slice().sort(function(a, b) {
+        if (Math.abs(a.centerY - b.centerY) > 1) return a.centerY - b.centerY
+        return a.centerX - b.centerX
+      })
+
+      var rGroup = []
+      for (var i = 0; i < geomSorted.length; i++) {
+        var itm = geomSorted[i]
+        var added = false
+        for (var r = 0; r < rGroup.length; r++) {
+          var rCy = rGroup[r].centerY
+          var rH = rGroup[r].height || itm.height || 1
+          if (Math.abs(itm.centerY - rCy) < rH * 0.5) {
+            rGroup[r].items.push(itm)
+            var sumY = 0
+            for (var k = 0; k < rGroup[r].items.length; k++) sumY += rGroup[r].items[k].centerY
+            rGroup[r].centerY = sumY / rGroup[r].items.length
+            added = true
+            break
+          }
+        }
+        if (!added) {
+          rGroup.push({ centerY: itm.centerY, height: itm.height, items: [itm] })
+        }
+      }
+      rGroup.sort(function(a, b) { return a.centerY - b.centerY })
+      for (var r = 0; r < rGroup.length; r++) {
+        rGroup[r].items.sort(function(a, b) { return a.centerX - b.centerX })
+        for (var c = 0; c < rGroup[r].items.length; c++) {
+          orderedItems.push(rGroup[r].items[c])
+        }
+      }
     }
-  }
 
-  // Sort rows top-to-bottom
-  rows.sort(function(a, b) { return a.centerY - b.centerY })
-
-  // Within each row, sort items left-to-right
-  for (var r = 0; r < rows.length; r++) {
-    rows[r].items.sort(function(a, b) { return a.centerX - b.centerX })
-  }
-
-  // Flatten rows into a continuous global visual sequence (reading order)
-  var orderedItems = []
-  for (var r = 0; r < rows.length; r++) {
-    for (var c = 0; c < rows[r].items.length; c++) {
-      orderedItems.push(rows[r].items[c])
+    var currentGlobalIndex = -1
+    for (var i = 0; i < orderedItems.length; i++) {
+      if (orderedItems[i].index === currentItem.index) {
+        currentGlobalIndex = i
+        break
+      }
     }
-  }
+    if (currentGlobalIndex === -1) currentGlobalIndex = 0
 
-  // Locate current item in orderedItems and in rows
-  var currentGlobalIndex = -1
-  for (var i = 0; i < orderedItems.length; i++) {
-    if (orderedItems[i] === currentItem) {
-      currentGlobalIndex = i
-      break
-    }
-  }
-  if (currentGlobalIndex === -1) currentGlobalIndex = 0
-
-  // 1. Horizontal navigation: one continuous global cycle
-  // Left / Right ignores row boundaries completely.
-  if (dx !== 0) {
     var total = orderedItems.length
     if (total <= 1) return orderedItems[0].index
 
@@ -593,6 +713,92 @@ function cyclicCardMove(items, currentIndex, dx, dy) {
 
   // 2. Vertical navigation: spatial row navigation with wrapping
   if (dy !== 0) {
+    // If a primary card exists alongside secondary cards (focused layout)
+    var primaryItem = null
+    var secondaryItems = []
+    for (var i = 0; i < validItems.length; i++) {
+      if (validItems[i].isPrimary) primaryItem = validItems[i]
+      else secondaryItems.push(validItems[i])
+    }
+
+    if (primaryItem && secondaryItems.length > 0) {
+      // In focused mode with single vertical rail, navigation moves up/down the global workspace sequence
+      var hasExplicitOrder = true
+      for (var i = 0; i < validItems.length; i++) {
+        if (validItems[i].visualOrder === undefined || validItems[i].visualOrder === null) {
+          hasExplicitOrder = false
+          break
+        }
+      }
+
+      var orderedItems = []
+      if (hasExplicitOrder) {
+        orderedItems = validItems.slice().sort(function(a, b) {
+          return a.visualOrder - b.visualOrder
+        })
+      } else {
+        orderedItems = validItems.slice().sort(function(a, b) {
+          return a.index - b.index
+        })
+      }
+
+      var currentGlobalIndex = -1
+      for (var i = 0; i < orderedItems.length; i++) {
+        if (orderedItems[i].index === currentItem.index) {
+          currentGlobalIndex = i
+          break
+        }
+      }
+      if (currentGlobalIndex === -1) currentGlobalIndex = 0
+
+      var total = orderedItems.length
+      if (total <= 1) return orderedItems[0].index
+
+      var nextGlobalIndex = currentGlobalIndex
+      if (dy > 0) {
+        nextGlobalIndex = (currentGlobalIndex + 1) % total
+      } else if (dy < 0) {
+        nextGlobalIndex = (currentGlobalIndex - 1 + total) % total
+      }
+      return orderedItems[nextGlobalIndex].index
+    }
+
+    // Default uniform row grouping for normal overview mode
+    var geomSorted = validItems.slice().sort(function(a, b) {
+      if (Math.abs(a.centerY - b.centerY) > 1) return a.centerY - b.centerY
+      return a.centerX - b.centerX
+    })
+
+    var rows = []
+    for (var i = 0; i < geomSorted.length; i++) {
+      var item = geomSorted[i]
+      var added = false
+      for (var r = 0; r < rows.length; r++) {
+        var rowCenterY = rows[r].centerY
+        var rowHeight = rows[r].height || item.height || 1
+        if (Math.abs(item.centerY - rowCenterY) < rowHeight * 0.5) {
+          rows[r].items.push(item)
+          var sumY = 0
+          for (var k = 0; k < rows[r].items.length; k++) sumY += rows[r].items[k].centerY
+          rows[r].centerY = sumY / rows[r].items.length
+          added = true
+          break
+        }
+      }
+      if (!added) {
+        rows.push({
+          centerY: item.centerY,
+          height: item.height,
+          items: [item]
+        })
+      }
+    }
+
+    rows.sort(function(a, b) { return a.centerY - b.centerY })
+    for (var r = 0; r < rows.length; r++) {
+      rows[r].items.sort(function(a, b) { return a.centerX - b.centerX })
+    }
+
     var currentRowIndex = -1
     for (var r = 0; r < rows.length; r++) {
       for (var c = 0; c < rows[r].items.length; c++) {

--- a/WorkspaceCard.qml
+++ b/WorkspaceCard.qml
@@ -140,6 +140,11 @@ BorderSurface {
     hoverEnabled: true
     cursorShape: Qt.PointingHandCursor
     onClicked: root.workspaceActivated(root.occupied)
+    onWheel: function(wheel) {
+      if (root.overview && typeof root.overview.scrollRail === "function") {
+        root.overview.scrollRail(wheel.angleDelta.y)
+      }
+    }
   }
 
   // Drag/keyboard/active fill overlay — provides surface tint during drag,

--- a/WorkspaceOverview.qml
+++ b/WorkspaceOverview.qml
@@ -17,6 +17,15 @@ Item {
   property var targetScreen: Quickshell.screens.length > 0 ? Quickshell.screens[0] : null
   property var draggedToplevel: null
   property int selectedCardIndex: -1
+  property string overviewMode: "normal"
+
+  function toggleOverviewMode() {
+    if (root.overviewMode === "focused") {
+      root.overviewMode = "normal"
+    } else {
+      root.overviewMode = "focused"
+    }
+  }
 
   // ── Bar geometry ────────────────────────────────────────────────────────────
   // `shell.bar` is the live Bar plugin instance injected by the shell loader.
@@ -76,6 +85,54 @@ Item {
   readonly property int rows: Math.max(1, gridGeometry.rows)
   readonly property real cardWidth: Math.max(1, gridGeometry.cardWidth)
   readonly property real cardHeight: Math.max(1, gridGeometry.cardHeight)
+
+  // ── Focused mode rail geometry & scrolling ─────────────────────────────────
+  property real railScrollY: 0
+
+  readonly property var focusedGeometry: {
+    if (root.overviewMode !== "focused") return null
+    var primIdx = root.selectedCardIndex >= 0 ? root.selectedCardIndex : 0
+    return WindowGeometry.focusedOverviewGeometry(
+      root.cardCount, primIdx, root.usableWidth, root.usableGridHeight,
+      root.cardAspectRatio, root.gridSpacing)
+  }
+  readonly property var railGeometry: focusedGeometry ? focusedGeometry.rail : null
+  readonly property real railX: railGeometry ? railGeometry.x : 0
+  readonly property real railWidth: railGeometry ? railGeometry.width : 0
+  readonly property real railHeight: railGeometry ? railGeometry.height : root.usableGridHeight
+  readonly property real railContentHeight: railGeometry ? railGeometry.contentHeight : 0
+  readonly property bool railScrollNeeded: railGeometry ? Boolean(railGeometry.scrollNeeded) : false
+  readonly property real railScrollMax: Math.max(0, root.railContentHeight - root.railHeight)
+
+  function scrollRail(deltaY) {
+    if (!root.railScrollNeeded) return
+    var step = (deltaY / 120.0) * Style.space(60)
+    var target = root.railScrollY - step
+    root.railScrollY = Math.max(0, Math.min(root.railScrollMax, target))
+  }
+
+  function ensureCardVisible(idx) {
+    if (root.overviewMode !== "focused" || !root.railScrollNeeded) return
+    var fg = root.focusedGeometry
+    if (!fg || !fg.cards || idx < 0 || idx >= fg.cards.length) return
+    var card = fg.cards[idx]
+    if (!card) return
+
+    var contentY = card.railContentY
+    var cardH = card.height
+    var viewH = root.railHeight
+    var margin = root.gridSpacing
+
+    if (contentY < root.railScrollY + margin) {
+      root.railScrollY = Math.max(0, contentY - margin)
+    } else if (contentY + cardH > root.railScrollY + viewH - margin) {
+      root.railScrollY = Math.min(root.railScrollMax, contentY + cardH - viewH + margin)
+    }
+  }
+
+  onSelectedCardIndexChanged: {
+    root.ensureCardVisible(root.selectedCardIndex)
+  }
 
   // ── Workspace helpers ───────────────────────────────────────────────────────
   function workspaceById(id) {
@@ -211,6 +268,15 @@ Item {
     return -1
   }
 
+  function focusedCardGeom(idx) {
+    if (root.overviewMode !== "focused" || idx < 0) return null
+    if (!root.focusedGeometry || !root.focusedGeometry.cards) return null
+    if (idx < root.focusedGeometry.cards.length) {
+      return root.focusedGeometry.cards[idx]
+    }
+    return null
+  }
+
   function normalCardGeom(idx) {
     if (idx < 0 || !root.gridGeometry || !root.gridGeometry.cards) return null
     if (idx < root.gridGeometry.cards.length) {
@@ -220,12 +286,20 @@ Item {
   }
 
   function slotWidth(idx) {
+    if (root.overviewMode === "focused") {
+      var card = root.focusedCardGeom(idx)
+      if (card && card.width > 0) return Math.round(card.width)
+    }
     var nCard = root.normalCardGeom(idx)
     if (nCard && nCard.width > 0) return Math.round(nCard.width)
     return Math.round(root.cardWidth)
   }
 
   function slotHeight(idx) {
+    if (root.overviewMode === "focused") {
+      var card = root.focusedCardGeom(idx)
+      if (card && card.height > 0) return Math.round(card.height)
+    }
     var nCard = root.normalCardGeom(idx)
     if (nCard && nCard.height > 0) return Math.round(nCard.height)
     return Math.round(root.cardHeight)
@@ -233,18 +307,29 @@ Item {
 
   function slotX(idx) {
     if (idx < 0) return 0
+    if (root.overviewMode === "focused") {
+      var card = root.focusedCardGeom(idx)
+      if (card) return Math.round(card.x)
+    }
     var nCard = root.normalCardGeom(idx)
-    if (nCard) return Math.round(root.usableX + nCard.x)
+    if (nCard) return Math.round(nCard.x)
     var col = idx % root.columns
-    return Math.round(root.usableX + root.gridGeometry.x + col * (root.cardWidth + root.gridSpacing))
+    return Math.round(root.gridGeometry.x + col * (root.cardWidth + root.gridSpacing))
   }
 
   function slotY(idx) {
     if (idx < 0) return 0
+    if (root.overviewMode === "focused") {
+      var card = root.focusedCardGeom(idx)
+      if (card) {
+        var yOffset = card.isPrimary ? 0 : root.railScrollY
+        return Math.round(card.y - yOffset)
+      }
+    }
     var nCard = root.normalCardGeom(idx)
-    if (nCard) return Math.round(root.usableGridY + nCard.y)
+    if (nCard) return Math.round(nCard.y)
     var row = Math.floor(idx / root.columns)
-    return Math.round(root.usableGridY + root.gridGeometry.y + row * (root.cardHeight + root.gridSpacing))
+    return Math.round(root.gridGeometry.y + row * (root.cardHeight + root.gridSpacing))
   }
 
   function workspaceNavigationItems() {
@@ -262,6 +347,8 @@ Item {
       var width = root.slotWidth(slotIdx)
       var height = root.slotHeight(slotIdx)
 
+      var isPrimary = (root.overviewMode === "focused" && slotIdx === (root.selectedCardIndex >= 0 ? root.selectedCardIndex : 0))
+
       items.push({
         index: slotIdx,
         workspaceId: wsId,
@@ -271,7 +358,9 @@ Item {
         height: height,
         centerX: gx + width / 2,
         centerY: gy + height / 2,
-        isInsertion: false
+        isInsertion: false,
+        isPrimary: isPrimary,
+        visualOrder: i
       })
     }
     return items
@@ -392,6 +481,8 @@ Item {
     root.targetScreen = root.focusedScreen()
     root.draggedToplevel = null
     root.selectedCardIndex = root.initialSelectedCardIndex()
+    root.overviewMode = "normal"
+    root.railScrollY = 0
 
     var payload = null
     try {
@@ -403,6 +494,9 @@ Item {
       payload = null
     }
     root.demoMode = Boolean(payload && payload.demo)
+    if (payload && (payload.focused || payload.mode === "focused")) {
+      root.overviewMode = "focused"
+    }
     root.opened = true
     Qt.callLater(function() {
       keyCatcher.forceActiveFocus()
@@ -416,6 +510,8 @@ Item {
     root.demoMode = false
     root.draggedToplevel = null
     root.selectedCardIndex = -1
+    root.overviewMode = "normal"
+    root.railScrollY = 0
     root.opened = false
     if (demoOverlay) demoOverlay.hideHint()
   }
@@ -424,6 +520,8 @@ Item {
     root.demoMode = false
     root.draggedToplevel = null
     root.selectedCardIndex = -1
+    root.overviewMode = "normal"
+    root.railScrollY = 0
     root.opened = false
     if (demoOverlay) demoOverlay.hideHint()
     if (root.shell && typeof root.shell.hide === "function")
@@ -546,8 +644,20 @@ Item {
       id: keyCatcher
       anchors.fill: parent
       focus: true
+      property bool returnHandled: false
+
       onMoveRequested: function(dx, dy) { root.moveCardSelection(dx, dy) }
-      onActivateRequested: root.activateSelectedCard()
+      onReturnRequested: {
+        keyCatcher.returnHandled = true
+        root.activateSelectedCard()
+      }
+      onActivateRequested: {
+        if (keyCatcher.returnHandled) {
+          keyCatcher.returnHandled = false
+          return
+        }
+        root.toggleOverviewMode()
+      }
       onCloseRequested: root.dismiss()
 
       Keys.onPressed: function(event) {
@@ -560,58 +670,93 @@ Item {
         }
       }
 
-      // ── Real Workspace Cards (Persistent across drag transitions) ──────────
-      Repeater {
-        model: root.workspaceModel
+      // ── Cards Viewport Container (Clips to usable overview bounds) ──────────
+      Item {
+        id: cardsContainer
+        x: root.usableX
+        y: root.usableGridY
+        width: root.usableWidth
+        height: root.usableGridHeight
+        clip: true
 
-        WorkspaceCard {
-          required property int modelData
-          required property int index
-
-          readonly property int slotIndex: root.slotIndexForWorkspace(modelData, root.draggedToplevel !== null)
-
-          x: root.slotX(slotIndex)
-          y: root.slotY(slotIndex)
-          width: root.slotWidth(slotIndex)
-          height: root.slotHeight(slotIndex)
-
-          overview: root
-          workspaceId: modelData
-          workspace: root.workspaceById(modelData)
-          livePreviews: root.opened && panel.visible
-          draggedToplevel: root.draggedToplevel
-          keyboardSelected: slotIndex === root.selectedCardIndex
-          focused: Hyprland.focusedWorkspace !== null
-          onWorkspaceActivated: function(occupied) {
-            root.selectedCardIndex = slotIndex
-            root.activateWorkspace(workspace, modelData, occupied)
+        // ── Secondary Rail Wheel Area (Scrolls rail without activating) ───────
+        MouseArea {
+          id: railWheelArea
+          x: root.railX
+          y: 0
+          width: root.railWidth
+          height: parent.height
+          visible: root.overviewMode === "focused" && root.railScrollNeeded
+          z: 0
+          acceptedButtons: Qt.NoButton
+          onWheel: function(wheel) {
+            root.scrollRail(wheel.angleDelta.y)
           }
-          onWindowActivated: function(toplevel) { root.activateWindow(toplevel) }
-          onWindowDragStarted: function(toplevel) { root.beginWindowDrag(toplevel) }
-          onWindowDragFinished: function(toplevel) { root.endWindowDrag(toplevel) }
-          onWindowDropped: function(toplevel) { root.moveWindowToWorkspace(toplevel, modelData) }
         }
-      }
 
-      // ── Temporary Insertion Workspace Cards (Active only during drag) ───────
-      Repeater {
-        model: root.insertionModel
+        // ── Real Workspace Cards (Persistent across drag transitions) ──────────
+        Repeater {
+          model: root.workspaceModel
 
-        InsertionWorkspaceCard {
-          required property int modelData
-          required property int index
+          WorkspaceCard {
+            required property int modelData
+            required property int index
 
-          readonly property int slotIndex: root.slotIndexForInsertion(modelData)
+            readonly property int slotIndex: root.slotIndexForWorkspace(modelData, root.draggedToplevel !== null)
+            readonly property bool isPrimaryFocusedCard: root.overviewMode === "focused" && slotIndex === (root.selectedCardIndex >= 0 ? root.selectedCardIndex : 0)
+            readonly property bool isRailSecondary: root.overviewMode === "focused" && !isPrimaryFocusedCard
 
-          x: root.slotX(slotIndex)
-          y: root.slotY(slotIndex)
-          width: root.slotWidth(slotIndex)
-          height: root.slotHeight(slotIndex)
+            x: root.slotX(slotIndex)
+            y: root.slotY(slotIndex)
+            width: root.slotWidth(slotIndex)
+            height: root.slotHeight(slotIndex)
 
-          overview: root
-          targetWorkspaceId: modelData
-          draggedToplevel: root.draggedToplevel
-          onWindowDropped: function(toplevel) { root.moveWindowToWorkspace(toplevel, modelData) }
+            overview: root
+            workspaceId: modelData
+            workspace: root.workspaceById(modelData)
+            livePreviews: {
+              if (!root.opened || !panel.visible) return false
+              if (root.overviewMode !== "focused") return true
+              return isPrimaryFocusedCard || (y + height >= root.usableGridY && y <= root.usableGridY + root.usableGridHeight)
+            }
+            draggedToplevel: root.draggedToplevel
+            keyboardSelected: slotIndex === root.selectedCardIndex
+            focused: Hyprland.focusedWorkspace !== null
+            onWorkspaceActivated: function(occupied) {
+              if (root.overviewMode === "focused" && root.selectedCardIndex !== slotIndex) {
+                root.selectedCardIndex = slotIndex
+                return
+              }
+              root.selectedCardIndex = slotIndex
+              root.activateWorkspace(workspace, modelData, occupied)
+            }
+            onWindowActivated: function(toplevel) { root.activateWindow(toplevel) }
+            onWindowDragStarted: function(toplevel) { root.beginWindowDrag(toplevel) }
+            onWindowDragFinished: function(toplevel) { root.endWindowDrag(toplevel) }
+            onWindowDropped: function(toplevel) { root.moveWindowToWorkspace(toplevel, modelData) }
+          }
+        }
+
+        // ── Temporary Insertion Workspace Cards (Active only during drag) ───────
+        Repeater {
+          model: root.insertionModel
+
+          InsertionWorkspaceCard {
+            required property int modelData
+            required property int index
+
+            readonly property int slotIndex: root.slotIndexForInsertion(modelData)
+
+            x: root.slotX(slotIndex)
+            y: root.slotY(slotIndex)
+            width: root.slotWidth(slotIndex)
+            height: root.slotHeight(slotIndex)
+
+            overview: root
+            targetWorkspaceId: modelData
+            draggedToplevel: root.draggedToplevel
+            onWindowDropped: function(toplevel) { root.moveWindowToWorkspace(toplevel, modelData) }
+          }
         }
       }
     }

--- a/bin/mirador
+++ b/bin/mirador
@@ -7,6 +7,7 @@ show_help() {
   cat << 'HELP'
 Usage:
   mirador            Toggle Mirador
+  mirador --focused  Open Mirador directly in focused workspace overview mode
   mirador --demo     Open Mirador with demo input overlay
   mirador --help     Show this help
   mirador --version  Show version information
@@ -16,6 +17,9 @@ HELP
 case "${1:-}" in
   "" )
     exec omarchy-shell shell toggle mirador '{}'
+    ;;
+  --focused | -f )
+    exec omarchy-shell shell summon mirador '{"focused":true}'
     ;;
   --demo )
     exec omarchy-shell shell summon mirador '{"demo":true}'

--- a/tests/tst_windowgeometry.qml
+++ b/tests/tst_windowgeometry.qml
@@ -706,5 +706,90 @@ TestCase {
       compare(g1.cards[i].width, g2.cards[i].width)
       compare(g1.cards[i].height, g2.cards[i].height)
     }
+
+    // In contrast, Focused mode geometry depends on primaryIndex (selection)
+    var f0 = WindowGeometry.focusedOverviewGeometry(5, 0, width, height, aspect, spacing)
+    var f1 = WindowGeometry.focusedOverviewGeometry(5, 1, width, height, aspect, spacing)
+    verify(f0.cards[0].isPrimary)
+    verify(!f0.cards[1].isPrimary)
+    verify(!f1.cards[0].isPrimary)
+    verify(f1.cards[1].isPrimary)
+  }
+
+  function test_focusedOverviewGeometry_singleCard() {
+    var result = WindowGeometry.focusedOverviewGeometry(1, 0, 1920, 1080, 1.55, 48)
+    compare(result.primaryIndex, 0)
+    compare(result.cards.length, 1)
+    verify(result.cards[0].isPrimary)
+    fuzzyCompare(result.cards[0].width, 1080 * 1.55)
+    fuzzyCompare(result.cards[0].height, 1080)
+  }
+
+  function test_focusedOverviewGeometry_allocationAndSpacing() {
+    var width = 1880
+    var height = 1000
+    var aspect = 1.55
+    var spacing = 48
+
+    var result = WindowGeometry.focusedOverviewGeometry(4, 1, width, height, aspect, spacing)
+    compare(result.primaryIndex, 1)
+    compare(result.cards.length, 4)
+
+    // Primary card occupies 1
+    var primary = result.cards[1]
+    verify(primary.isPrimary)
+    verify(primary.width > width * 0.65, "Primary card occupies >65% of width")
+    fuzzyCompare(primary.width / primary.height, aspect)
+
+    // Secondary cards form a vertical rail
+    verify(result.rail !== null, "Rail geometry must be defined")
+    compare(result.rail.width, result.cards[0].width)
+    fuzzyCompare(result.rail.width / result.cards[0].height, aspect)
+
+    // Verify all 3 secondary cards have the exact same size
+    compare(result.cards[0].width, result.cards[2].width)
+    compare(result.cards[0].width, result.cards[3].width)
+    compare(result.cards[0].height, result.cards[2].height)
+    compare(result.cards[0].height, result.cards[3].height)
+    verify(!result.cards[0].isPrimary)
+    verify(!result.cards[2].isPrimary)
+    verify(!result.cards[3].isPrimary)
+
+    // Total width matches primary + gap + rail
+    var totalUsedW = primary.width + spacing + result.rail.width
+    fuzzyCompare(result.cards[0].x, primary.x + primary.width + spacing)
+  }
+
+  function test_focusedOverviewGeometry_cyclicNavigation() {
+    var width = 1880
+    var height = 1000
+    var aspect = 1.55
+    var spacing = 48
+
+    var result = WindowGeometry.focusedOverviewGeometry(4, 0, width, height, aspect, spacing)
+    var navItems = []
+    for (var i = 0; i < result.cards.length; i++) {
+      var c = result.cards[i]
+      navItems.push({
+        index: i,
+        workspaceId: i + 1,
+        x: c.x,
+        y: c.y,
+        width: c.width,
+        height: c.height,
+        centerX: c.x + c.width / 2,
+        centerY: c.y + c.height / 2,
+        isInsertion: false,
+        isPrimary: c.isPrimary,
+        visualOrder: i
+      })
+    }
+
+    // Right from primary (0) moves to rail item (1)
+    compare(WindowGeometry.cyclicCardMove(navItems, 0, 1, 0), 1)
+    // Left from rail item (1) moves back to primary (0)
+    compare(WindowGeometry.cyclicCardMove(navItems, 1, -1, 0), 0)
+    // Down from rail item 1 moves to rail item 2
+    compare(WindowGeometry.cyclicCardMove(navItems, 1, 0, 1), 2)
   }
 }

--- a/tests/tst_workspaceoverview_integration.qml
+++ b/tests/tst_workspaceoverview_integration.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtTest 1.3
+import "../WindowGeometry.js" as WindowGeometry
 
 TestCase {
   name: "WorkspaceOverviewIntegration"
@@ -321,5 +322,82 @@ TestCase {
     var gridGeomDecl = source.match(/readonly\s+property\s+var\s+gridGeometry\s*:\s*WindowGeometry\.overviewGridGeometry[\s\S]*?\)/)
     verify(gridGeomDecl && !/selectedCardIndex/.test(gridGeomDecl[0]),
       "gridGeometry must never depend on selectedCardIndex (selection must not alter Normal mode geometry)")
+  }
+
+  function test_focusedOverviewModePropertiesAndKeyHandling() {
+    var source = workspaceOverviewSource()
+    // Overview must declare overviewMode defaulting to "normal"
+    verify(/property string overviewMode\s*:\s*"normal"/.test(source))
+    // Overview must have toggleOverviewMode()
+    verify(/function toggleOverviewMode\(\)/.test(source))
+    // Return key activates card; Space key (onActivateRequested) toggles overviewMode
+    verify(/onReturnRequested[\s\S]*root\.activateSelectedCard\(\)/.test(source))
+    verify(/onActivateRequested[\s\S]*root\.toggleOverviewMode\(\)/.test(source))
+    // Focused mode uses dynamic card dimensions
+    verify(/function slotWidth\(/.test(source))
+    verify(/function slotHeight\(/.test(source))
+    verify(/WindowGeometry\.focusedOverviewGeometry/.test(source))
+    // Dismissing resets overviewMode to "normal"
+    verify(/root\.overviewMode\s*=\s*"normal"/.test(source))
+  }
+
+  function test_focusedOverviewRailScrollingAndWheelIntegration() {
+    var source = workspaceOverviewSource()
+    var cardSource = workspaceCardSource()
+
+    // Must declare rail scrolling properties
+    verify(/property real railScrollY\s*:\s*0/.test(source))
+    verify(/readonly property bool railScrollNeeded/.test(source))
+    verify(/readonly property real railScrollMax/.test(source))
+    verify(/function scrollRail\(/.test(source))
+    verify(/function ensureCardVisible\(/.test(source))
+    verify(/onSelectedCardIndexChanged\s*:\s*\{[\s\S]*root\.ensureCardVisible/.test(source))
+
+    // Must clip cards inside cardsContainer
+    verify(/id\s*:\s*cardsContainer/.test(source))
+    verify(/clip\s*:\s*true/.test(source))
+
+    // Must have rail wheel capture that does not steal clicks
+    verify(/id\s*:\s*railWheelArea/.test(source))
+    verify(/acceptedButtons\s*:\s*Qt\.NoButton/.test(source))
+    verify(/root\.scrollRail\(wheel\.angleDelta\.y\)/.test(source))
+
+    // WorkspaceCard forwards mouse wheel to overview without activation
+    verify(/cardMouseArea[\s\S]*onWheel\s*:\s*function\(wheel\)/.test(cardSource))
+    verify(/root\.overview\.scrollRail\(wheel\.angleDelta\.y\)/.test(cardSource))
+  }
+
+  function test_focusedOverviewPromotionAndNoDuplicates() {
+    // Test geometry promotion with 5 workspaces
+    for (var prim = 0; prim < 5; prim++) {
+      var geom = WindowGeometry.focusedOverviewGeometry(5, prim, 1920, 1080, 1.55, 48)
+      compare(geom.cards.length, 5)
+      compare(geom.primaryIndex, prim)
+      verify(geom.cards[prim].isPrimary)
+
+      var primaryCount = 0
+      var secondaryCount = 0
+      var seenIndices = {}
+
+      for (var i = 0; i < geom.cards.length; i++) {
+        var card = geom.cards[i]
+        verify(card !== null)
+        verify(!seenIndices[card.index], "Duplicate card index detected: " + card.index)
+        seenIndices[card.index] = true
+
+        if (card.isPrimary) {
+          primaryCount++
+          compare(card.index, prim)
+        } else {
+          secondaryCount++
+          verify(card.index !== prim)
+          compare(card.x, geom.rail.x)
+          compare(card.width, geom.rail.width)
+        }
+      }
+
+      compare(primaryCount, 1, "Exactly one primary workspace")
+      compare(secondaryCount, 4, "Remaining workspaces are secondary rail items")
+    }
   }
 }


### PR DESCRIPTION
## Summary
Introduces Focused overview mode featuring a large primary workspace card (>65% screen width) alongside a single vertical scrollable rail of secondary cards.

## Key Changes
- Implement `WindowGeometry.focusedOverviewGeometry(count, primaryIndex, availableWidth, availableHeight, cardAspectRatio, spacing)` to allocate primary card and rail geometry.
- Support mode switching via `toggleOverviewMode()` (Space key) and CLI `--focused` parameter.
- Implement two-way workspace promotion: clicking or navigating to any rail item promotes it to primary.
- Add vertical rail scrolling with clamp logic (`scrollRail(delta)` and `railScrollY`) ensuring smooth mouse-wheel/touchpad traversal.
- Add comprehensive unit and integration tests.