### PR TITLE
feat(gestures): add 3-finger swipe integration, 2-finger pinch mode switching, and wheel navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,15 +38,18 @@ mirador/
 ├── InsertionWorkspaceCard.qml # Drag-and-drop workspace insertion placeholder
 ├── WindowGeometry.js          # Pure JS: multi-monitor scaling, 2D cyclic move, pixel snapping
 ├── WindowModel.js             # Pure JS: Hyprland group resolution, address normalization
+├── GestureHelper.js           # Pure JS: pinch gesture threshold and one-shot debounce logic
+├── mirador.gestures.lua       # Hyprland 3-finger swipe gesture configuration snippet
 ├── DemoInputOverlay.qml       # Session-scoped demo recording HUD
 ├── bin/
-│   └── mirador                # CLI launcher script (toggle, --demo, --version)
+│   └── mirador                # CLI launcher script (toggle, --summon, --dismiss, --focused, --demo)
 ├── docs/
 │   ├── architecture.md        # Deep architecture & Wayland protocol specifications
 │   └── testing.md             # Automated & manual test procedures
 └── tests/
     ├── tst_windowgeometry.qml # Geometry & cyclic navigation unit tests
     ├── tst_windowmodel.qml    # Window group & deduplication unit tests
+    ├── tst_gesturehelper.qml  # Pinch gesture threshold & debounce unit tests
     ├── tst_windowpreview_security.qml # Security & capture release tests
     ├── tst_workspaceoverview_integration.qml # Integration & UI tests
     └── tst_demo_overlay.qml   # Demo overlay unit tests

--- a/GestureHelper.js
+++ b/GestureHelper.js
@@ -1,0 +1,80 @@
+// Pure JS gesture decision helper for Mirador overview mode transitions.
+// Contains threshold evaluation, deadband checking, and one-shot debounce logic
+// without depending on QML or Qt types, allowing comprehensive automated unit testing.
+
+.pragma library
+
+// Default pinch threshold: 10% scale divergence from 1.0.
+// Requires scale >= 1.10 for pinch-out (spread) or <= 0.90 for pinch-in (squeeze).
+var PINCH_THRESHOLD = 0.10;
+
+/**
+ * Checks whether the pinch scale represents an outward spread gesture exceeding threshold.
+ * @param {number} scale Current scale relative to gesture start (1.0 = neutral).
+ * @param {number} [threshold] Optional custom threshold fraction (defaults to PINCH_THRESHOLD).
+ * @returns {boolean}
+ */
+function isPinchOut(scale, threshold) {
+  if (typeof scale !== "number" || isNaN(scale) || scale <= 0) return false;
+  var th = (typeof threshold === "number" && !isNaN(threshold) && threshold > 0)
+    ? threshold
+    : PINCH_THRESHOLD;
+  return scale >= (1.0 + th);
+}
+
+/**
+ * Checks whether the pinch scale represents an inward squeeze gesture exceeding threshold.
+ * @param {number} scale Current scale relative to gesture start (1.0 = neutral).
+ * @param {number} [threshold] Optional custom threshold fraction (defaults to PINCH_THRESHOLD).
+ * @returns {boolean}
+ */
+function isPinchIn(scale, threshold) {
+  if (typeof scale !== "number" || isNaN(scale) || scale <= 0) return false;
+  var th = (typeof threshold === "number" && !isNaN(threshold) && threshold > 0)
+    ? threshold
+    : PINCH_THRESHOLD;
+  return scale <= (1.0 - th);
+}
+
+/**
+ * Determines whether a pinch gesture should trigger a mode transition.
+ *
+ * Invariants:
+ * - If gestureTriggered is true, always returns null (enforcing one-shot per gesture).
+ * - In "normal" mode: only outward pinch (scale >= 1.0 + threshold) transitions to "focused".
+ *   Inward pinch in normal mode is ignored (returns null).
+ * - In "focused" mode: only inward pinch (scale <= 1.0 - threshold) transitions to "normal".
+ *   Outward pinch in focused mode is ignored (returns null).
+ * - Small fluctuations (within 1.0 +/- threshold) are ignored as deadband, preventing accidental
+ *   triggers during two-finger scrolling.
+ *
+ * @param {string} currentMode Current overview mode ("normal" or "focused").
+ * @param {number} scale Current gesture scale relative to gesture start.
+ * @param {boolean} gestureTriggered Whether a transition was already fired in the ongoing gesture.
+ * @param {number} [threshold] Configurable pinch threshold (defaults to PINCH_THRESHOLD).
+ * @returns {string|null} Target mode ("normal" or "focused"), or null if no transition should occur.
+ */
+function shouldTriggerTransition(currentMode, scale, gestureTriggered, threshold) {
+  if (gestureTriggered) {
+    return null;
+  }
+  if (typeof scale !== "number" || isNaN(scale) || scale <= 0) {
+    return null;
+  }
+
+  var th = (typeof threshold === "number" && !isNaN(threshold) && threshold > 0)
+    ? threshold
+    : PINCH_THRESHOLD;
+
+  if (currentMode === "normal") {
+    if (scale >= (1.0 + th)) {
+      return "focused";
+    }
+  } else if (currentMode === "focused") {
+    if (scale <= (1.0 - th)) {
+      return "normal";
+    }
+  }
+
+  return null;
+}

--- a/WorkspaceCard.qml
+++ b/WorkspaceCard.qml
@@ -141,7 +141,16 @@ BorderSurface {
     cursorShape: Qt.PointingHandCursor
     onClicked: root.workspaceActivated(root.occupied)
     onWheel: function(wheel) {
-      if (root.overview && typeof root.overview.scrollRail === "function") {
+      var isTouchpadScroll = Boolean(wheel.pixelDelta && (wheel.pixelDelta.x !== 0 || wheel.pixelDelta.y !== 0))
+      var isRailSecondary = Boolean(root.overview && root.overview.overviewMode === "focused" && !root.isPrimary)
+
+      if (isRailSecondary && (isTouchpadScroll || (root.overview && root.overview.railScrollNeeded))) {
+        if (root.overview && typeof root.overview.scrollRail === "function") {
+          root.overview.scrollRail(wheel.angleDelta.y)
+        }
+      } else if (root.overview && typeof root.overview.handleCardWheel === "function") {
+        root.overview.handleCardWheel(root.isPrimary, wheel.angleDelta.x, wheel.angleDelta.y)
+      } else if (root.overview && typeof root.overview.scrollRail === "function") {
         root.overview.scrollRail(wheel.angleDelta.y)
       }
     }

--- a/WorkspaceOverview.qml
+++ b/WorkspaceOverview.qml
@@ -5,6 +5,7 @@ import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
 import "WindowGeometry.js" as WindowGeometry
+import "GestureHelper.js" as GestureHelper
 
 Item {
   id: root
@@ -19,11 +20,100 @@ Item {
   property int selectedCardIndex: -1
   property string overviewMode: "normal"
 
+  function setOverviewMode(mode) {
+    if (mode !== "normal" && mode !== "focused") return
+    if (root.overviewMode === mode) return
+    root.overviewMode = mode
+    root.railScrollY = 0
+    root.wheelDeltaAccumulatorX = 0
+    root.wheelDeltaAccumulatorY = 0
+    if (mode === "focused") {
+      root.ensureCardVisible(root.selectedCardIndex)
+    }
+  }
+
   function toggleOverviewMode() {
     if (root.overviewMode === "focused") {
-      root.overviewMode = "normal"
+      root.setOverviewMode("normal")
     } else {
-      root.overviewMode = "focused"
+      root.setOverviewMode("focused")
+    }
+  }
+
+  // ── Pinch gesture handling ──────────────────────────────────────────────────
+  readonly property real pinchThreshold: GestureHelper.PINCH_THRESHOLD
+  property bool pinchTriggered: false
+
+  function handlePinchScale(scale) {
+    if (root.pinchTriggered) return
+    var targetMode = GestureHelper.shouldTriggerTransition(
+      root.overviewMode, scale, root.pinchTriggered, root.pinchThreshold)
+    if (targetMode) {
+      root.pinchTriggered = true
+      root.setOverviewMode(targetMode)
+    }
+  }
+
+  function handlePinchActiveChanged(active) {
+    if (!active) {
+      root.pinchTriggered = false
+    }
+  }
+
+  // ── Cursor wheel workspace navigation ─────────────────────────────
+  // Mode-specific navigation:
+  // In Normal mode:
+  // - vertical wheel down = Right arrow / l -> moveCardSelection(1, 0)  (endless global cycle forward)
+  // - vertical wheel up   = Left arrow / h  -> moveCardSelection(-1, 0) (endless global cycle backward)
+  // In Focused mode:
+  // - vertical wheel down = Down arrow / j -> moveCardSelection(0, 1)  (spatial row down)
+  // - vertical wheel up   = Up arrow / k   -> moveCardSelection(0, -1) (spatial row up)
+  // In both modes:
+  // - horizontal wheel right = Right arrow / l -> moveCardSelection(1, 0)
+  // - horizontal wheel left  = Left arrow / h  -> moveCardSelection(-1, 0)
+  property real wheelDeltaAccumulatorX: 0
+  property real wheelDeltaAccumulatorY: 0
+
+  function handleWheelNavigation(deltaX, deltaY) {
+    var threshold = 60
+    if (Math.abs(deltaY) >= Math.abs(deltaX) && deltaY !== 0) {
+      root.wheelDeltaAccumulatorX = 0
+      root.wheelDeltaAccumulatorY += deltaY
+      if (root.overviewMode === "normal") {
+        if (root.wheelDeltaAccumulatorY <= -threshold) {
+          root.moveCardSelection(1, 0)  // wheel down = global next (Right arrow / l)
+          root.wheelDeltaAccumulatorY = 0
+        } else if (root.wheelDeltaAccumulatorY >= threshold) {
+          root.moveCardSelection(-1, 0) // wheel up = global previous (Left arrow / h)
+          root.wheelDeltaAccumulatorY = 0
+        }
+      } else {
+        if (root.wheelDeltaAccumulatorY <= -threshold) {
+          root.moveCardSelection(0, 1)  // wheel down = Down arrow / j
+          root.wheelDeltaAccumulatorY = 0
+        } else if (root.wheelDeltaAccumulatorY >= threshold) {
+          root.moveCardSelection(0, -1) // wheel up = Up arrow / k
+          root.wheelDeltaAccumulatorY = 0
+        }
+      }
+    } else if (deltaX !== 0) {
+      root.wheelDeltaAccumulatorY = 0
+      root.wheelDeltaAccumulatorX += deltaX
+      if (root.wheelDeltaAccumulatorX >= threshold) {
+        root.moveCardSelection(1, 0)  // wheel right = Right arrow / l
+        root.wheelDeltaAccumulatorX = 0
+      } else if (root.wheelDeltaAccumulatorX <= -threshold) {
+        root.moveCardSelection(-1, 0) // wheel left = Left arrow / h
+        root.wheelDeltaAccumulatorX = 0
+      }
+    }
+  }
+
+  function handleCardWheel(isPrimary, deltaX, deltaY) {
+    if (root.overviewMode === "focused" && !isPrimary && root.railScrollNeeded) {
+      root.scrollRail(deltaY)
+    } else {
+      root.handleWheelNavigation(deltaX, deltaY)
     }
   }
 
@@ -483,6 +573,9 @@ Item {
     root.selectedCardIndex = root.initialSelectedCardIndex()
     root.overviewMode = "normal"
     root.railScrollY = 0
+    root.pinchTriggered = false
+    root.wheelDeltaAccumulatorX = 0
+    root.wheelDeltaAccumulatorY = 0
 
     var payload = null
     try {
@@ -512,6 +605,9 @@ Item {
     root.selectedCardIndex = -1
     root.overviewMode = "normal"
     root.railScrollY = 0
+    root.pinchTriggered = false
+    root.wheelDeltaAccumulatorX = 0
+    root.wheelDeltaAccumulatorY = 0
     root.opened = false
     if (demoOverlay) demoOverlay.hideHint()
   }
@@ -522,6 +618,9 @@ Item {
     root.selectedCardIndex = -1
     root.overviewMode = "normal"
     root.railScrollY = 0
+    root.pinchTriggered = false
+    root.wheelDeltaAccumulatorX = 0
+    root.wheelDeltaAccumulatorY = 0
     root.opened = false
     if (demoOverlay) demoOverlay.hideHint()
     if (root.shell && typeof root.shell.hide === "function")
@@ -638,6 +737,9 @@ Item {
     MouseArea {
       anchors.fill: parent
       onClicked: root.dismiss()
+      onWheel: function(wheel) {
+        root.handleWheelNavigation(wheel.angleDelta.x, wheel.angleDelta.y)
+      }
     }
 
     PanelKeyCatcher {
@@ -645,6 +747,15 @@ Item {
       anchors.fill: parent
       focus: true
       property bool returnHandled: false
+
+      // ── Cursor wheel arrow-key workspace navigation ─────────────────────────
+      WheelHandler {
+        id: catcherWheelHandler
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+        onWheel: function(event) {
+          root.handleWheelNavigation(event.angleDelta.x, event.angleDelta.y)
+        }
+      }
 
       onMoveRequested: function(dx, dy) { root.moveCardSelection(dx, dy) }
       onReturnRequested: {
@@ -667,6 +778,24 @@ Item {
         if (event.key === Qt.Key_Plus || event.key === Qt.Key_Equal || event.text === "+" || event.text === "=") {
           event.accepted = true
           root.createNewWorkspace()
+        }
+      }
+
+      // ── Two-finger pinch handler (native QtQuick pointer handler) ───────────
+      PinchHandler {
+        id: pinchHandler
+        target: null
+        grabPermissions: PointerHandler.CanTakeOverFromAnything
+        onActiveChanged: {
+          root.handlePinchActiveChanged(active)
+        }
+        onScaleChanged: function(delta) {
+          var s = (activeScale > 0) ? activeScale : scale
+          root.handlePinchScale(s)
+        }
+        onUpdated: {
+          var s = (activeScale > 0) ? activeScale : scale
+          root.handlePinchScale(s)
         }
       }
 

--- a/bin/mirador
+++ b/bin/mirador
@@ -8,6 +8,8 @@ show_help() {
 Usage:
   mirador            Toggle Mirador
   mirador --focused  Open Mirador directly in focused workspace overview mode
+  mirador --summon   Summon/open Mirador
+  mirador --dismiss  Dismiss/close Mirador
   mirador --demo     Open Mirador with demo input overlay
   mirador --help     Show this help
   mirador --version  Show version information
@@ -20,6 +22,12 @@ case "${1:-}" in
     ;;
   --focused | -f )
     exec omarchy-shell shell summon mirador '{"focused":true}'
+    ;;
+  --summon | summon )
+    exec omarchy-shell shell summon mirador '{}'
+    ;;
+  --dismiss | dismiss | --hide | hide )
+    exec omarchy-shell shell hide mirador
     ;;
   --demo )
     exec omarchy-shell shell summon mirador '{"demo":true}'

--- a/mirador.gestures.lua
+++ b/mirador.gestures.lua
@@ -1,0 +1,25 @@
+-- Mirador Gesture Configuration for Hyprland (Lua)
+--
+-- 3-Finger Swipe Up   -> Summon Mirador (open in Normal mode, idempotent)
+-- 3-Finger Swipe Down -> Dismiss Mirador (cleanly releases screencopy buffers, safe no-op when closed)
+--
+-- To use this standalone snippet, you can load it in ~/.config/hypr/input.lua:
+--   dofile((os.getenv("HOME") .. "/Projects/omarchy_plugins/mirador/mirador.gestures.lua"))
+--
+-- Or include the lines below directly in ~/.config/hypr/input.lua:
+
+hl.gesture({
+  fingers = 3,
+  direction = "up",
+  action = function()
+    hl.dispatch(hl.dsp.exec_cmd("omarchy-shell shell summon mirador '{}'"))
+  end,
+})
+
+hl.gesture({
+  fingers = 3,
+  direction = "down",
+  action = function()
+    hl.dispatch(hl.dsp.exec_cmd("omarchy-shell shell hide mirador"))
+  end,
+})

--- a/tests/tst_gesturehelper.qml
+++ b/tests/tst_gesturehelper.qml
@@ -1,0 +1,128 @@
+import QtQuick 2.15
+import QtTest 1.0
+import "../GestureHelper.js" as GestureHelper
+
+TestCase {
+  name: "GestureHelperUnitTests"
+
+  function test_pinchThresholdDefaults() {
+    compare(GestureHelper.PINCH_THRESHOLD, 0.10, "Default pinch threshold should be 10%")
+  }
+
+  function test_isPinchOut() {
+    // Neutral
+    verify(!GestureHelper.isPinchOut(1.0), "Neutral scale 1.0 is not pinch-out")
+    // Minor changes within deadband (< 10%)
+    verify(!GestureHelper.isPinchOut(1.04), "1.04 is within deadband")
+    verify(!GestureHelper.isPinchOut(1.09), "1.09 is below 10% threshold")
+    // At and above threshold
+    verify(GestureHelper.isPinchOut(1.10), "1.10 is at 10% threshold")
+    verify(GestureHelper.isPinchOut(1.25), "1.25 is above 10% threshold")
+    // Inward scaling
+    verify(!GestureHelper.isPinchOut(0.90), "0.90 is pinch-in, not pinch-out")
+    // Invalid inputs
+    verify(!GestureHelper.isPinchOut(null), "null scale should return false")
+    verify(!GestureHelper.isPinchOut(undefined), "undefined scale should return false")
+    verify(!GestureHelper.isPinchOut(NaN), "NaN scale should return false")
+    verify(!GestureHelper.isPinchOut(0), "0 scale should return false")
+    verify(!GestureHelper.isPinchOut(-1.5), "Negative scale should return false")
+    // Custom threshold
+    verify(GestureHelper.isPinchOut(1.16, 0.15), "1.16 exceeds custom 15% threshold")
+    verify(!GestureHelper.isPinchOut(1.14, 0.15), "1.14 is below custom 15% threshold")
+  }
+
+  function test_isPinchIn() {
+    // Neutral
+    verify(!GestureHelper.isPinchIn(1.0), "Neutral scale 1.0 is not pinch-in")
+    // Minor changes within deadband (< 10%)
+    verify(!GestureHelper.isPinchIn(0.96), "0.96 is within deadband")
+    verify(!GestureHelper.isPinchIn(0.91), "0.91 is above 0.90 threshold")
+    // At and below threshold
+    verify(GestureHelper.isPinchIn(0.90), "0.90 is at 10% threshold")
+    verify(GestureHelper.isPinchIn(0.75), "0.75 is below 10% threshold")
+    // Outward scaling
+    verify(!GestureHelper.isPinchIn(1.10), "1.10 is pinch-out, not pinch-in")
+    // Invalid inputs
+    verify(!GestureHelper.isPinchIn(null), "null scale should return false")
+    verify(!GestureHelper.isPinchIn(undefined), "undefined scale should return false")
+    verify(!GestureHelper.isPinchIn(NaN), "NaN scale should return false")
+    verify(!GestureHelper.isPinchIn(0), "0 scale should return false")
+    verify(!GestureHelper.isPinchIn(-0.5), "Negative scale should return false")
+    // Custom threshold
+    verify(GestureHelper.isPinchIn(0.84, 0.15), "0.84 exceeds custom 15% threshold (<= 0.85)")
+    verify(!GestureHelper.isPinchIn(0.86, 0.15), "0.86 is above custom 15% threshold (> 0.85)")
+  }
+
+  function test_shouldTriggerTransition_normalMode() {
+    // In normal mode, only outward pinch (spread) transitions to focused mode
+    compare(GestureHelper.shouldTriggerTransition("normal", 1.0, false), null, "Neutral scale should not trigger")
+    compare(GestureHelper.shouldTriggerTransition("normal", 1.05, false), null, "5% spread is below threshold")
+    compare(GestureHelper.shouldTriggerTransition("normal", 1.10, false), "focused", "10% spread should trigger focused")
+    compare(GestureHelper.shouldTriggerTransition("normal", 1.20, false), "focused", "20% spread should trigger focused")
+
+    // Inward pinch in normal mode must NOT trigger anything
+    compare(GestureHelper.shouldTriggerTransition("normal", 0.80, false), null, "Inward pinch in normal mode is ignored")
+    compare(GestureHelper.shouldTriggerTransition("normal", 0.50, false), null, "Strong inward pinch in normal mode is ignored")
+  }
+
+  function test_shouldTriggerTransition_focusedMode() {
+    // In focused mode, only inward pinch (squeeze) transitions to normal mode
+    compare(GestureHelper.shouldTriggerTransition("focused", 1.0, false), null, "Neutral scale should not trigger")
+    compare(GestureHelper.shouldTriggerTransition("focused", 0.95, false), null, "5% squeeze is below threshold")
+    compare(GestureHelper.shouldTriggerTransition("focused", 0.90, false), "normal", "10% squeeze should trigger normal")
+    compare(GestureHelper.shouldTriggerTransition("focused", 0.70, false), "normal", "30% squeeze should trigger normal")
+
+    // Outward pinch in focused mode must NOT trigger anything
+    compare(GestureHelper.shouldTriggerTransition("focused", 1.20, false), null, "Outward pinch in focused mode is ignored")
+    compare(GestureHelper.shouldTriggerTransition("focused", 1.50, false), null, "Strong outward pinch in focused mode is ignored")
+  }
+
+  function test_shouldTriggerTransition_oneShotDebounce() {
+    var mode = "normal"
+    var gestureTriggered = false
+
+    // Step 1: Small motion under threshold
+    var target = GestureHelper.shouldTriggerTransition(mode, 1.04, gestureTriggered)
+    compare(target, null, "Minor motion under threshold should not fire")
+
+    // Step 2: Scale crosses threshold -> fires transition to focused
+    target = GestureHelper.shouldTriggerTransition(mode, 1.12, gestureTriggered)
+    compare(target, "focused", "Exceeding threshold fires transition to focused")
+
+    // Consumer applies transition and marks gesture as triggered
+    mode = target
+    gestureTriggered = true
+
+    // Step 3: Ongoing gesture continues or moves further outward
+    target = GestureHelper.shouldTriggerTransition(mode, 1.25, gestureTriggered)
+    compare(target, null, "Ongoing gesture must NOT re-trigger (one-shot invariant)")
+
+    // Step 4: Even if user moves fingers inward in the SAME ongoing gesture, do not toggle back!
+    target = GestureHelper.shouldTriggerTransition(mode, 0.75, gestureTriggered)
+    compare(target, null, "Inward reversal in SAME active gesture must NOT fire until gesture ends")
+
+    // Step 5: User lifts fingers -> gesture resets
+    gestureTriggered = false
+
+    // Step 6: Next gesture: user pinches inward to return to normal
+    target = GestureHelper.shouldTriggerTransition(mode, 0.88, gestureTriggered)
+    compare(target, "normal", "New gesture pinching inward transitions back to normal")
+
+    mode = target
+    gestureTriggered = true
+
+    // Step 7: Ongoing gesture ignored again
+    target = GestureHelper.shouldTriggerTransition(mode, 0.70, gestureTriggered)
+    compare(target, null, "Ongoing gesture ignored")
+  }
+
+  function test_shouldTriggerTransition_customThreshold() {
+    // 10% threshold
+    compare(GestureHelper.shouldTriggerTransition("normal", 1.11, false, 0.10), "focused")
+    compare(GestureHelper.shouldTriggerTransition("normal", 1.08, false, 0.10), null)
+
+    // 20% threshold
+    compare(GestureHelper.shouldTriggerTransition("focused", 0.85, false, 0.20), null)
+    compare(GestureHelper.shouldTriggerTransition("focused", 0.79, false, 0.20), "normal")
+  }
+}

--- a/tests/tst_windowgeometry.qml
+++ b/tests/tst_windowgeometry.qml
@@ -370,6 +370,153 @@ TestCase {
     compare(WindowGeometry.cyclicCardMove(layout, 1, 0, -1), 5)
   }
 
+  function test_wheelNavigationMatchesArrowKeysDirectly() {
+    // Layout:
+    // [1] [4]
+    // [5]
+    var layout = [
+      { index: 1, x: 0, y: 0, width: 80, height: 60 },
+      { index: 4, x: 100, y: 0, width: 80, height: 60 },
+      { index: 5, x: 0, y: 100, width: 80, height: 60 }
+    ]
+
+    var workspaces = [1, 4, 5]
+
+    for (var i = 0; i < workspaces.length; i++) {
+      var ws = workspaces[i]
+
+      // 1. Wheel Down must match Down arrow (dy = 1) exactly
+      var wheelDownTarget = WindowGeometry.cyclicCardMove(layout, ws, 0, 1)
+      var downArrowTarget = WindowGeometry.cyclicCardMove(layout, ws, 0, 1)
+      compare(wheelDownTarget, downArrowTarget, "Wheel down from WS " + ws + " must match Down arrow")
+
+      // 2. Wheel Up must match Up arrow (dy = -1) exactly
+      var wheelUpTarget = WindowGeometry.cyclicCardMove(layout, ws, 0, -1)
+      var upArrowTarget = WindowGeometry.cyclicCardMove(layout, ws, 0, -1)
+      compare(wheelUpTarget, upArrowTarget, "Wheel up from WS " + ws + " must match Up arrow")
+
+      // 3. Wheel Right must match Right arrow (dx = 1) exactly
+      var wheelRightTarget = WindowGeometry.cyclicCardMove(layout, ws, 1, 0)
+      var rightArrowTarget = WindowGeometry.cyclicCardMove(layout, ws, 1, 0)
+      compare(wheelRightTarget, rightArrowTarget, "Wheel right from WS " + ws + " must match Right arrow")
+
+      // 4. Wheel Left must match Left arrow (dx = -1) exactly
+      var wheelLeftTarget = WindowGeometry.cyclicCardMove(layout, ws, -1, 0)
+      var leftArrowTarget = WindowGeometry.cyclicCardMove(layout, ws, -1, 0)
+      compare(wheelLeftTarget, leftArrowTarget, "Wheel left from WS " + ws + " must match Left arrow")
+    }
+
+    // Specific assertions matching user's expected mapping:
+    // From WS1:
+    compare(WindowGeometry.cyclicCardMove(layout, 1, 0, 1), 5, "From WS1 wheel down -> WS5")
+    compare(WindowGeometry.cyclicCardMove(layout, 1, 0, -1), 5, "From WS1 wheel up -> WS5")
+
+    // From WS4:
+    compare(WindowGeometry.cyclicCardMove(layout, 4, 0, 1), 5, "From WS4 wheel down -> WS5")
+    compare(WindowGeometry.cyclicCardMove(layout, 4, 0, -1), 5, "From WS4 wheel up -> WS5")
+
+    // From WS5:
+    compare(WindowGeometry.cyclicCardMove(layout, 5, 0, -1), 1, "From WS5 wheel up -> WS1")
+    compare(WindowGeometry.cyclicCardMove(layout, 5, 0, 1), 1, "From WS5 wheel down -> WS1")
+
+    // Horizontal global cycle:
+    // wheel right: 1 -> 4 -> 5 -> 1
+    compare(WindowGeometry.cyclicCardMove(layout, 1, 1, 0), 4, "From WS1 wheel right -> WS4")
+    compare(WindowGeometry.cyclicCardMove(layout, 4, 1, 0), 5, "From WS4 wheel right -> WS5")
+    compare(WindowGeometry.cyclicCardMove(layout, 5, 1, 0), 1, "From WS5 wheel right -> WS1")
+
+    // wheel left: 1 -> 5 -> 4 -> 1
+    compare(WindowGeometry.cyclicCardMove(layout, 1, -1, 0), 5, "From WS1 wheel left -> WS5")
+    compare(WindowGeometry.cyclicCardMove(layout, 5, -1, 0), 4, "From WS5 wheel left -> WS4")
+    compare(WindowGeometry.cyclicCardMove(layout, 4, -1, 0), 1, "From WS4 wheel left -> WS1")
+  }
+
+  function test_normalModeWheelGlobalCycle_4WorkspaceGrid() {
+    // 4-workspace grid in Normal mode:
+    // [1] [2]
+    // [3] [4]
+    var grid4 = [
+      { index: 1, x: 0, y: 0, width: 80, height: 60 },
+      { index: 2, x: 100, y: 0, width: 80, height: 60 },
+      { index: 3, x: 0, y: 100, width: 80, height: 60 },
+      { index: 4, x: 100, y: 100, width: 80, height: 60 }
+    ]
+
+    // Normal mode Wheel Down reuses Right arrow / l (dx: 1, dy: 0):
+    // Expected cycle: 1 -> 2 -> 3 -> 4 -> 1 -> 2
+    var cur = 1
+    var expectedDown = [2, 3, 4, 1, 2]
+    for (var i = 0; i < expectedDown.length; i++) {
+      cur = WindowGeometry.cyclicCardMove(grid4, cur, 1, 0)
+      compare(cur, expectedDown[i], "Normal mode wheel down step " + i)
+    }
+
+    // Normal mode Wheel Up reuses Left arrow / h (dx: -1, dy: 0):
+    // Expected cycle: 1 -> 4 -> 3 -> 2 -> 1 -> 4
+    cur = 1
+    var expectedUp = [4, 3, 2, 1, 4]
+    for (var j = 0; j < expectedUp.length; j++) {
+      cur = WindowGeometry.cyclicCardMove(grid4, cur, -1, 0)
+      compare(cur, expectedUp[j], "Normal mode wheel up step " + j)
+    }
+
+    // If currently selected workspace is 4:
+    // wheel down: 4 -> 1 -> 2 -> 3 -> 4 -> 1
+    cur = 4
+    var from4Down = [1, 2, 3, 4, 1]
+    for (var k = 0; k < from4Down.length; k++) {
+      cur = WindowGeometry.cyclicCardMove(grid4, cur, 1, 0)
+      compare(cur, from4Down[k], "From WS4 wheel down step " + k)
+    }
+
+    // Horizontal wheel / tilt equivalence:
+    // wheel right == wheel down (dx: 1, dy: 0)
+    // wheel left == wheel up (dx: -1, dy: 0)
+    compare(WindowGeometry.cyclicCardMove(grid4, 1, 1, 0), 2)
+    compare(WindowGeometry.cyclicCardMove(grid4, 1, -1, 0), 4)
+  }
+
+  function test_normalModeWheelIrregularIds() {
+    // Irregular non-contiguous workspace IDs:
+    // [1]  [4]
+    // [7]  [10]
+    var irregular = [
+      { index: 1, x: 0, y: 0, width: 80, height: 60 },
+      { index: 4, x: 100, y: 0, width: 80, height: 60 },
+      { index: 7, x: 0, y: 100, width: 80, height: 60 },
+      { index: 10, x: 100, y: 100, width: 80, height: 60 }
+    ]
+
+    // Wheel Down: cycles strictly by visual position: 1 -> 4 -> 7 -> 10 -> 1 -> 4
+    var cur = 1
+    var expectedDown = [4, 7, 10, 1, 4]
+    for (var i = 0; i < expectedDown.length; i++) {
+      cur = WindowGeometry.cyclicCardMove(irregular, cur, 1, 0)
+      compare(cur, expectedDown[i], "Irregular IDs wheel down step " + i)
+    }
+
+    // Wheel Up: cycles strictly in reverse visual position: 1 -> 10 -> 7 -> 4 -> 1 -> 10
+    cur = 1
+    var expectedUp = [10, 7, 4, 1, 10]
+    for (var j = 0; j < expectedUp.length; j++) {
+      cur = WindowGeometry.cyclicCardMove(irregular, cur, -1, 0)
+      compare(cur, expectedUp[j], "Irregular IDs wheel up step " + j)
+    }
+
+    // Also verify with explicit visualOrder (as supplied by WorkspaceOverview):
+    var withVisualOrder = [
+      { index: 1, visualOrder: 0, x: 0, y: 0, width: 80, height: 60 },
+      { index: 4, visualOrder: 1, x: 100, y: 0, width: 80, height: 60 },
+      { index: 7, visualOrder: 2, x: 0, y: 100, width: 80, height: 60 },
+      { index: 10, visualOrder: 3, x: 100, y: 100, width: 80, height: 60 }
+    ]
+    cur = 1
+    for (var m = 0; m < expectedDown.length; m++) {
+      cur = WindowGeometry.cyclicCardMove(withVisualOrder, cur, 1, 0)
+      compare(cur, expectedDown[m], "With visualOrder wheel down step " + m)
+    }
+  }
+
   function test_cyclicNavigation_threeRowExample() {
     // [1] [2] [3]
     // [4]     [5]

--- a/tests/tst_workspaceoverview_integration.qml
+++ b/tests/tst_workspaceoverview_integration.qml
@@ -400,4 +400,114 @@ TestCase {
       compare(secondaryCount, 4, "Remaining workspaces are secondary rail items")
     }
   }
+
+  function test_pinchGestureIntegrationAndStateConvergence() {
+    var source = workspaceOverviewSource()
+
+    // 1. GestureHelper import
+    verify(/import\s+"GestureHelper\.js"\s+as\s+GestureHelper/.test(source),
+      "WorkspaceOverview must import GestureHelper.js")
+
+    // 2. Pinch threshold and triggered state properties
+    verify(/readonly\s+property\s+real\s+pinchThreshold\s*:\s*GestureHelper\.PINCH_THRESHOLD/.test(source),
+      "WorkspaceOverview must declare pinchThreshold referencing GestureHelper.PINCH_THRESHOLD")
+    verify(/property\s+bool\s+pinchTriggered\s*:\s*false/.test(source),
+      "WorkspaceOverview must declare pinchTriggered boolean property")
+
+    // 3. Mode state machine convergence (setOverviewMode & toggleOverviewMode)
+    verify(/function\s+setOverviewMode\(mode\)/.test(source),
+      "WorkspaceOverview must define unified setOverviewMode(mode)")
+    verify(/function\s+toggleOverviewMode\(\)/.test(source),
+      "WorkspaceOverview must define toggleOverviewMode()")
+    verify(/root\.setOverviewMode\("normal"\)/.test(source),
+      "toggleOverviewMode must delegate to setOverviewMode('normal')")
+    verify(/root\.setOverviewMode\("focused"\)/.test(source),
+      "toggleOverviewMode must delegate to setOverviewMode('focused')")
+
+    // 4. Pinch event handling functions
+    verify(/function\s+handlePinchScale\(scale\)/.test(source),
+      "WorkspaceOverview must declare handlePinchScale(scale)")
+    verify(/function\s+handlePinchActiveChanged\(active\)/.test(source),
+      "WorkspaceOverview must declare handlePinchActiveChanged(active)")
+
+    // 5. One-shot debounce guard in handlePinchScale
+    verify(/if\s*\(root\.pinchTriggered\)\s*return/.test(source),
+      "handlePinchScale must bail out early if pinchTriggered is already true")
+    verify(/GestureHelper\.shouldTriggerTransition/.test(source),
+      "handlePinchScale must delegate transition decision to GestureHelper")
+
+    // 6. Reset on active == false
+    verify(/if\s*\(!active\)\s*\{\s*root\.pinchTriggered\s*=\s*false\s*\}/.test(source),
+      "handlePinchActiveChanged must reset pinchTriggered when fingers are lifted (active == false)")
+
+    // 7. Reset on open(), close(), dismiss()
+    var openMatch = source.match(/function\s+open\(payloadJson\)[\s\S]*?\n  \}/)
+    verify(openMatch && /root\.pinchTriggered\s*=\s*false/.test(openMatch[0]),
+      "open() must reset pinchTriggered to false")
+    var closeMatch = source.match(/function\s+close\(\)[\s\S]*?\n  \}/)
+    verify(closeMatch && /root\.pinchTriggered\s*=\s*false/.test(closeMatch[0]),
+      "close() must reset pinchTriggered to false")
+    var dismissMatch = source.match(/function\s+dismiss\(\)[\s\S]*?\n  \}/)
+    verify(dismissMatch && /root\.pinchTriggered\s*=\s*false/.test(dismissMatch[0]),
+      "dismiss() must reset pinchTriggered to false")
+
+    // 8. PinchHandler declaration inside PanelWindow / keyCatcher
+    verify(/PinchHandler\s*\{/.test(source),
+      "WorkspaceOverview must declare a native PinchHandler")
+    verify(/target\s*:\s*null/.test(source),
+      "PinchHandler must set target: null to prevent continuous rescaling blur")
+    verify(/grabPermissions\s*:\s*PointerHandler\.CanTakeOverFromAnything/.test(source),
+      "PinchHandler must declare grabPermissions")
+    verify(/onActiveChanged\s*:\s*\{\s*root\.handlePinchActiveChanged\(active\)\s*\}/.test(source),
+      "PinchHandler must wire onActiveChanged to root.handlePinchActiveChanged")
+  }
+
+  function test_wheelNavigationArrowKeyDirectMappingAndTouchpadDistinction() {
+    var source = workspaceOverviewSource()
+    var cardSource = workspaceCardSource()
+
+    // 1. Wheel accumulators and navigation function
+    verify(/property\s+real\s+wheelDeltaAccumulatorX\s*:\s*0/.test(source),
+      "WorkspaceOverview must declare wheelDeltaAccumulatorX")
+    verify(/property\s+real\s+wheelDeltaAccumulatorY\s*:\s*0/.test(source),
+      "WorkspaceOverview must declare wheelDeltaAccumulatorY")
+    verify(/function\s+handleWheelNavigation\(deltaX,\s*deltaY\)/.test(source),
+      "WorkspaceOverview must define handleWheelNavigation(deltaX, deltaY)")
+
+    // 2. Mode-specific wheel navigation branching:
+    // Normal mode: endless visual cycle
+    // - Wheel down -> Right arrow / l -> moveCardSelection(1, 0)
+    // - Wheel up   -> Left arrow / h  -> moveCardSelection(-1, 0)
+    // Focused mode: spatial row navigation
+    // - Wheel down -> Down arrow / j -> moveCardSelection(0, 1)
+    // - Wheel up   -> Up arrow / k   -> moveCardSelection(0, -1)
+    verify(/if\s*\(root\.overviewMode\s*===\s*"normal"\)/.test(source),
+      "handleWheelNavigation must branch based on overviewMode === 'normal'")
+    verify(/root\.moveCardSelection\(1,\s*0\)/.test(source),
+      "Normal mode wheel down & horizontal right must call moveCardSelection(1, 0)")
+    verify(/root\.moveCardSelection\(-1,\s*0\)/.test(source),
+      "Normal mode wheel up & horizontal left must call moveCardSelection(-1, 0)")
+    verify(/root\.moveCardSelection\(0,\s*1\)/.test(source),
+      "Focused mode wheel down must call moveCardSelection(0, 1)")
+    verify(/root\.moveCardSelection\(0,\s*-1\)/.test(source),
+      "Focused mode wheel up must call moveCardSelection(0, -1)")
+
+    // 3. One wheel detent threshold (60)
+    verify(/var\s+threshold\s*=\s*60/.test(source),
+      "handleWheelNavigation must use a 60-unit accumulator threshold for 1-detent mapping")
+
+    // 4. Background MouseArea and keyCatcher WheelHandler wiring
+    verify(/MouseArea[\s\S]*onWheel\s*:\s*function\(wheel\)\s*\{\s*root\.handleWheelNavigation\(wheel\.angleDelta\.x,\s*wheel\.angleDelta\.y\)/.test(source),
+      "Background MouseArea must forward wheel events to handleWheelNavigation")
+    verify(/WheelHandler[\s\S]*id\s*:\s*catcherWheelHandler/.test(source),
+      "keyCatcher must include catcherWheelHandler for overview-wide wheel reception")
+
+    // 5. Touchpad scroll distinction in WorkspaceCard.qml
+    verify(/isTouchpadScroll\s*=\s*Boolean\(wheel\.pixelDelta/.test(cardSource),
+      "WorkspaceCard must inspect wheel.pixelDelta to distinguish touchpad two-finger scroll from mouse wheel")
+    verify(/isRailSecondary\s*&&/.test(cardSource),
+      "WorkspaceCard must preserve two-finger scrolling in focused secondary rail")
+    verify(/root\.overview\.handleCardWheel/.test(cardSource),
+      "WorkspaceCard must delegate normal mode and primary card wheel to handleCardWheel")
+  }
 }


### PR DESCRIPTION
## Summary
Adds gesture-driven interactions and mode-aware mouse-wheel/touchpad navigation.

## Key Changes
- Hyprland 3-finger swipe up/down configuration snippet (`mirador.gestures.lua`) and CLI summon/dismiss integration.
- 2-finger pinch-out (switch to focused mode) and pinch-in (return to normal mode) using native QtQuick `PinchHandler` and `GestureHelper.js` with 0.10 threshold and one-shot debounce.
- Mode-aware cursor wheel workspace navigation:
  - Normal mode: vertical wheel down/up cycles continuously in global visual order (wrapping endlessly).
  - Focused mode: vertical wheel down/up performs spatial arrow navigation (Up/Down / k/j).
  - Horizontal wheel/tilt maps to Left/Right arrow navigation across all modes.
  - Distinguishes touchpad two-finger scroll from mouse wheel (`wheel.pixelDelta`) to keep secondary rail scrolling smooth.
- Add unit tests for `GestureHelper.js`, wheel navigation in `tst_windowgeometry.qml`, and integration tests in `tst_workspaceoverview_integration.qml`.